### PR TITLE
build: replace hardcoded MQ SDK paths with $(MQ_HOME) env var (P3.1)

### DIFF
--- a/Client/Client.vcxproj
+++ b/Client/Client.vcxproj
@@ -137,7 +137,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;MQCLIENT;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -164,7 +164,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;MQCLIENT;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -193,7 +193,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;MQCLIENT;SAFE_MODE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -220,14 +220,14 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_WIN64;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;MQCLIENT;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)rfhutilc$(TargetExt)</OutputFile>
-      <AdditionalLibraryDirectories>d:\apps\mq\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MQ_HOME)\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>
@@ -248,7 +248,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_WIN64;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;MQCLIENT;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -257,7 +257,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)rfhutilc$(TargetExt)</OutputFile>
-      <AdditionalLibraryDirectories>d:\apps\mq\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MQ_HOME)\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>
@@ -278,7 +278,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_WIN64;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;MQCLIENT;SAFE_MODE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -287,7 +287,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)rfhutilc-safe$(TargetExt)</OutputFile>
-      <AdditionalLibraryDirectories>d:\apps\mq\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MQ_HOME)\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    MQ_HOME: path to IBM MQ installation root.
+    Override by setting the MQ_HOME environment variable before building,
+    or by passing /p:MQ_HOME=<path> to msbuild.
+    Default matches the standard IBM MQ 64-bit client installation on Windows.
+  -->
+  <PropertyGroup>
+    <MQ_HOME Condition="'$(MQ_HOME)' == ''">C:\Program Files\IBM\MQ</MQ_HOME>
+  </PropertyGroup>
+</Project>

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## 📊 Progress Tracker
 
-**Last Updated:** April 8, 2026
+**Last Updated:** April 13, 2026
 **Current Version:** 9.4.0.0
 **Build Environment:** Visual Studio 2022 (v143), IBM MQ 9.4.5
 
@@ -15,6 +15,7 @@
 | 🔴 **P0.3** | Connection Settings UI Tab | ✅ COMPLETE | Feb 14, 2026 | 15th tab with 3 sections, 28 controls |
 | 🟡 **P1.1** | Visual Studio 2022 Upgrade | ✅ COMPLETE | Feb 14, 2026 | Already using VS 2022 Build Tools |
 | 🟡 **P1.2** | Dark Mode Support | ✅ COMPLETE | Feb 21, 2026 | Full implementation with visual polish |
+| 🟡 **P1.2b** | Safe Mode Build | ✅ COMPLETE | Feb 20, 2026 | `ReleaseSafe` config, `rfhutilc-safe.exe`, SAFE_MODE guard disables all write ops |
 | 🟡 **P1.3** | 64-bit Support | ✅ COMPLETE | Feb 23, 2026 | x64 platform, fixed MFC handlers, 32 files |
 | 🟡 **P1.4** | Basic Unit Testing | ✅ COMPLETE | Mar 20, 2026 | 132 tests across 5 modules, Win32+x64 |
 | 🟢 **P2.1** | Connection Health Monitor | ✅ COMPLETE | Apr 8, 2026 | WM_TIMER + MQINQ probes, live status in Connection Settings tab |
@@ -56,6 +57,7 @@ This document provides a **detailed, actionable roadmap** for modernizing the mq
 | 🔴 **P0.3** | Add tab to enable auto-reconnect and heartbeat/keepalive | Medium | High | Low | ✅ DONE |
 | 🟡 **P1.1** | Upgrade to VS 2022 | Low | Medium | Low | ✅ DONE |
 | 🟡 **P1.2** | Dark mode | Low | Medium | Low | ✅ DONE |
+| 🟡 **P1.2b** | Safe mode (browse-only build) | Low | High | Low | ✅ DONE |
 
 
 ### Short Term (Weeks 5-12)

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## 📊 Progress Tracker
 
-**Last Updated:** April 13, 2026
+**Last Updated:** April 13, 2026 (P3.1 complete)
 **Current Version:** 9.4.0.0
 **Build Environment:** Visual Studio 2022 (v143), IBM MQ 9.4.5
 
@@ -21,6 +21,7 @@
 | 🟢 **P2.1** | Connection Health Monitor | ✅ COMPLETE | Apr 8, 2026 | WM_TIMER + MQINQ probes, live status in Connection Settings tab |
 | 🟢 **P2.2** | Secure Credential Storage | ✅ COMPLETE | Apr 8, 2026 | Windows DPAPI, base64 registry storage, opt-in per connection |
 | 🟢 **P2.3** | Editable Data Tab | ✅ COMPLETE | Apr 8, 2026 | Allow Edit checkbox + Write Q button, Character and Hex round-trip |
+| 🔴 **P3.1** | Fix hardcoded MQ SDK paths | ✅ COMPLETE | Apr 13, 2026 | `Directory.Build.props` with `$(MQ_HOME)`, defaults to `C:\Program Files\IBM\MQ` |
 
 ### In Progress 🚧
 
@@ -32,7 +33,6 @@
 
 | Priority | Item | Effort | Impact | Target Quarter |
 |----------|------|--------|--------|----------------|
-| 🔴 **P3.1** | Fix hardcoded MQ SDK paths | Small | High | Q2 2026 |
 | 🟡 **P3.2** | GitHub Actions — build + unit tests | Small | High | Q2 2026 |
 | 🟡 **P3.3** | Expand tests — header parsing (RFH1/RFH2, DLQ, CICS, IMS) | Medium | High | Q2 2026 |
 | 🟡 **P3.4** | Expand tests — message encoding (EBCDIC, hex, JSON, XML) | Medium | High | Q2 2026 |
@@ -80,7 +80,7 @@ This document provides a **detailed, actionable roadmap** for modernizing the mq
 
 | Priority | Item | Effort | Impact | Risk | Notes |
 |----------|------|--------|--------|------|-------|
-| 🔴 **P3.1** | Fix hardcoded MQ SDK paths | Small | High | Low | Replace `d:\apps\mq\` with `$(MQ_HOME)` env var in all .vcxproj files |
+| 🔴 **P3.1** | Fix hardcoded MQ SDK paths | Small | High | Low | ✅ DONE — `Directory.Build.props` with `$(MQ_HOME)`, override via env var or `/p:MQ_HOME=` |
 | 🟡 **P3.2** | GitHub Actions — build + unit tests | Small | High | Low | Windows runner, Win32+x64 matrix, Google Test output |
 | 🟡 **P3.3** | Expand tests — header parsing | Medium | High | Low | RFH1, RFH2, DLQ, CICS, IMS header build/parse coverage |
 | 🟡 **P3.4** | Expand tests — message encoding | Medium | High | Low | EBCDIC, hex, JSON, XML round-trips |
@@ -116,7 +116,7 @@ This document provides a **detailed, actionable roadmap** for modernizing the mq
 All P0–P2 items shipped. Key deliverables: heartbeat/reconnect, dark mode, safe mode, 64-bit, unit testing, health monitor, DPAPI credentials, editable data tab.
 
 ### Phase 2: CI/CD & Coverage (Q2–Q3 2026)
-1. **P3.1** — Parameterize MQ SDK paths (unblocks CI and other contributors)
+1. **P3.1** ✅ — Parameterize MQ SDK paths (`Directory.Build.props`, `$(MQ_HOME)`)
 2. **P3.2** — GitHub Actions basic workflow
 3. **P3.3–P3.6** — Expand test coverage to core logic areas
 4. **P3.7–P3.10** — Smaller quality improvements in parallel

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -1,0 +1,494 @@
+# RFHUtil Modernization Roadmap - Detailed Action Plan
+
+## 📊 Progress Tracker
+
+**Last Updated:** April 8, 2026
+**Current Version:** 9.4.0.0
+**Build Environment:** Visual Studio 2022 (v143), IBM MQ 9.4.5
+
+### Completed Items ✅
+
+| Priority | Item | Status | Completed Date | Notes |
+|----------|------|--------|----------------|-------|
+| 🔴 **P0.1** | HeartBeat/KeepAlive Configuration | ✅ COMPLETE | Feb 14, 2026 | Added to DataArea with UI controls |
+| 🔴 **P0.2** | Automatic Reconnection | ✅ COMPLETE | Feb 14, 2026 | Exponential backoff, 7 error handlers |
+| 🔴 **P0.3** | Connection Settings UI Tab | ✅ COMPLETE | Feb 14, 2026 | 15th tab with 3 sections, 28 controls |
+| 🟡 **P1.1** | Visual Studio 2022 Upgrade | ✅ COMPLETE | Feb 14, 2026 | Already using VS 2022 Build Tools |
+| 🟡 **P1.2** | Dark Mode Support | ✅ COMPLETE | Feb 21, 2026 | Full implementation with visual polish |
+| 🟡 **P1.3** | 64-bit Support | ✅ COMPLETE | Feb 23, 2026 | x64 platform, fixed MFC handlers, 32 files |
+| 🟡 **P1.4** | Basic Unit Testing | ✅ COMPLETE | Mar 20, 2026 | 132 tests across 5 modules, Win32+x64 |
+| 🟢 **P2.1** | Connection Health Monitor | ✅ COMPLETE | Apr 8, 2026 | WM_TIMER + MQINQ probes, live status in Connection Settings tab |
+| 🟢 **P2.2** | Secure Credential Storage | ✅ COMPLETE | Apr 8, 2026 | Windows DPAPI, base64 registry storage, opt-in per connection |
+| 🟢 **P2.3** | Editable Data Tab | ✅ COMPLETE | Apr 8, 2026 | Allow Edit checkbox + Write Q button, Character and Hex round-trip |
+
+### In Progress 🚧
+
+| Priority | Item | Status | Started Date | Target Date |
+|----------|------|--------|--------------|-------------|
+| None | - | - | - | - |
+
+### Upcoming 📋
+
+| Priority | Item | Effort | Impact | Target Quarter |
+|----------|------|--------|--------|----------------|
+| 🟢 **P2** | Refactor DataArea Class | High | High | Q3 2026 |
+| 🟢 **P2** | Modern C++ Features | High | Medium | Q3 2026 |
+| 🔵 **P3** | CMake Build System | Medium | Low | Q3 2026 |
+| 🔵 **P3** | Comprehensive Testing | High | High | Q3 2026 |
+| 🟡 **P4** | GitHub Actions CI/CD | Medium | High | Q4 2026 |
+
+---
+
+## Executive Summary
+
+This document provides a **detailed, actionable roadmap** for modernizing the mq-rfhutil project. Each recommendation includes specific steps, code examples, and expected outcomes.
+
+---
+
+## Priority Matrix
+
+### Immediate Impact (Do First - Weeks 1-4)
+
+| Priority | Item | Effort | Impact | Risk | Status |
+|----------|------|--------|--------|------|--------|
+| 🔴 **P0.1** | Add HeartBeat/KeepAlive | Low | High | Low | ✅ DONE |
+| 🔴 **P0.2** | Implement Auto-Reconnect | Medium | High | Low | ✅ DONE |
+| 🔴 **P0.3** | Add tab to enable auto-reconnect and heartbeat/keepalive | Medium | High | Low | ✅ DONE |
+| 🟡 **P1.1** | Upgrade to VS 2022 | Low | Medium | Low | ✅ DONE |
+| 🟡 **P1.2** | Dark mode | Low | Medium | Low | ✅ DONE |
+
+
+### Short Term (Weeks 5-12)
+
+| Priority | Item | Effort | Impact | Risk | Status |
+|----------|------|--------|--------|------|--------|
+| 🟡 **P1.4** | Basic Unit Testing | Medium | High | Low | ✅ DONE |
+| 🟢 **P2.1** | Connection Health Monitor | Medium | Medium | Low | ✅ DONE |
+| 🟢 **P2.2** | Secure Credential Storage | Medium | High | Medium | ✅ DONE |
+| 🟢 **P2.3** | Make the Data tab editable by adding a check mark and allow for that data to be written to the queue | Medium | Medium | Medium | ✅ DONE |
+
+### Medium Term (Months 4-6)
+
+| Priority | Item | Effort | Impact | Risk |
+|----------|------|--------|--------|------|
+| 🟢 **P2** | Refactor DataArea Class | High | High | Medium |
+| 🟢 **P2** | Modern C++ Features | High | Medium | Medium |
+| 🔵 **P3** | CMake Build System | Medium | Low | Medium |
+| 🔵 **P3** | Comprehensive Testing | High | High | Low |
+| 🟡 **P4** | Add GitHub Actions CI/CD | Medium | High | Low |
+
+---
+
+## 1. IMMEDIATE: Connection Reliability (P0)
+
+### 1.1 Add HeartBeat and KeepAlive Configuration
+
+**Problem:** Current code doesn't set these, leading to slow failure detection and firewall timeouts.
+
+**Solution:** Add explicit configuration in connection setup.
+
+#### Implementation Steps
+
+**Step 1: Locate the connection code**
+- File: [`RFHUtil/DataArea.cpp`](RFHUtil/DataArea.cpp:10350-10450)
+- Method: `DataArea::connect2QM()`
+- Line: After 10407 (after `cd.MaxMsgLength = 104857600;`)
+
+**Step 2: Add the configuration**
+
+```cpp
+// File: RFHUtil/DataArea.cpp
+// Location: After line 10407
+
+// ============================================================
+// MODERNIZATION: Add HeartBeat and KeepAlive configuration
+// ============================================================
+
+// Set HeartBeat interval for fast MQ-level failure detection
+// This detects queue manager crashes, process failures, and keeps
+// the connection active to prevent firewall timeouts
+cd.HeartBeatInterval = 60;  // 60 seconds (vs default 300s)
+
+// Set KeepAlive interval for network-level failure detection
+// This detects network cable unplugs, router failures, and
+// "half-open" TCP connections
+cd.KeepAliveInterval = MQKAI_AUTO;  // Use OS defaults
+
+// For environments with aggressive firewalls (5-minute timeout):
+// cd.KeepAliveInterval = 30;  // 30 seconds
+
+// Ensure we're using a version that supports these fields
+if (cd.Version < MQCD_VERSION_7) {
+    cd.Version = MQCD_VERSION_7;
+    cd.StrucLength = MQCD_LENGTH_7;
+}
+
+// Add trace logging
+if (traceEnabled) {
+    sprintf(traceInfo, "HeartBeat=%d, KeepAlive=%d", 
+            cd.HeartBeatInterval, cd.KeepAliveInterval);
+    logTraceEntry(traceInfo);
+}
+```
+
+**Step 3: Test the changes**
+
+```cpp
+// Test scenarios:
+// 1. Normal connection - verify heartbeats are sent
+// 2. Network disconnect - verify fast detection
+// 3. QM crash - verify fast detection
+// 4. Long idle period - verify no firewall timeout
+```
+
+#### Expected Outcomes
+
+**Before:**
+- Failure detection: 300+ seconds (5+ minutes)
+- Firewall timeouts: Common after 5 minutes idle
+- User experience: Poor (long waits, manual reconnects)
+
+**After:**
+- Failure detection: 60 seconds (5x faster)
+- Firewall timeouts: Eliminated (heartbeats keep connection alive)
+- User experience: Excellent (fast detection, automatic recovery)
+
+#### Effort Estimate
+- **Development:** 1 hour
+- **Testing:** 2 hours
+- **Documentation:** 1 hour
+- **Total:** 4 hours
+
+---
+
+### 1.2 Implement Automatic Reconnection
+
+**Problem:** When connection fails, user must manually reconnect. Poor user experience.
+
+**Solution:** Add automatic reconnection with exponential backoff.
+
+#### Implementation Steps
+
+**Step 1: Create ConnectionManager class**
+
+Create new file: `RFHUtil/ConnectionManager.h`
+
+```cpp
+/*
+ * ConnectionManager.h
+ * Manages MQ connections with automatic reconnection
+ */
+
+#ifndef CONNECTION_MANAGER_H
+#define CONNECTION_MANAGER_H
+
+#include "cmqc.h"
+#include <string>
+
+class ConnectionManager {
+public:
+    // Configuration
+    struct Config {
+        int maxRetries = 3;
+        int initialDelayMs = 1000;      // 1 second
+        int maxDelayMs = 30000;         // 30 seconds
+        double backoffMultiplier = 2.0; // Exponential backoff
+        bool enableAutoReconnect = true;
+    };
+
+    ConnectionManager();
+    ~ConnectionManager();
+
+    // Connection management
+    bool connect(const char* qmName, const Config& config = Config());
+    bool disconnect();
+    bool isConnected() const;
+    bool ensureConnected();  // Check and reconnect if needed
+
+    // Health monitoring
+    bool isHealthy();
+    MQLONG getLastCompletionCode() const { return lastCC; }
+    MQLONG getLastReasonCode() const { return lastRC; }
+    const char* getLastError() const { return lastError.c_str(); }
+
+    // Connection handle
+    MQHCONN getHandle() const { return qm; }
+
+private:
+    MQHCONN qm;
+    bool connected;
+    std::string currentQM;
+    Config config;
+    
+    // Error tracking
+    MQLONG lastCC;
+    MQLONG lastRC;
+    std::string lastError;
+    
+    // Reconnection state
+    int reconnectAttempts;
+    DWORD lastReconnectTime;
+
+    // Internal methods
+    bool connectInternal(const char* qmName);
+    bool reconnect();
+    int calculateBackoffDelay(int attempt);
+    void logConnectionEvent(const char* event);
+};
+
+#endif // CONNECTION_MANAGER_H
+```
+
+**Step 2: Integrate with DataArea**
+
+Modify `RFHUtil/DataArea.h`:
+
+```cpp
+// Add to DataArea class
+private:
+    ConnectionManager* connMgr;  // New connection manager
+
+public:
+    // Add new methods
+    bool connectWithRetry(const char* qmName);
+    bool ensureConnection();
+```
+
+#### Effort Estimate
+- **Development:** 8 hours
+- **Testing:** 4 hours
+- **Integration:** 4 hours
+- **Documentation:** 2 hours
+- **Total:** 18 hours (2-3 days)
+
+---
+
+## 2. SHORT TERM: Build System Modernization (P1)
+
+### 2.1 Upgrade to Visual Studio 2022
+
+**Status:** ✅ DONE — Already using VS 2022 (v143) with Windows SDK 10.0.
+
+---
+
+### 2.2 Add 64-bit Support
+
+**Status:** ✅ DONE — x64 platform configuration added, 32 files fixed.
+
+---
+
+### 2.3 Implement GitHub Actions CI/CD
+
+**Problem:** No automated builds or testing. Manual release process.
+
+**Solution:** Add GitHub Actions for automated CI/CD.
+
+#### Implementation Steps
+
+**Step 1: Create Workflow File**
+
+Create `.github/workflows/build-and-test.yml`:
+
+```yaml
+name: Build and Test
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ created ]
+
+env:
+  MQ_VERSION: 9.3.0.0
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }} ${{ matrix.configuration }}
+    runs-on: windows-2022
+    
+    strategy:
+      matrix:
+        platform: [Win32, x64]
+        configuration: [Release, Debug]
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+    
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v2
+    
+    - name: Cache MQ Installation
+      id: cache-mq
+      uses: actions/cache@v4
+      with:
+        path: C:\Program Files\IBM\MQ
+        key: mq-${{ env.MQ_VERSION }}-${{ matrix.platform }}
+    
+    - name: Install IBM MQ Client
+      if: steps.cache-mq.outputs.cache-hit != 'true'
+      run: |
+        # Download and install MQ client
+        echo "Installing MQ Client..."
+    
+    - name: Restore NuGet packages
+      run: nuget restore RFHUtil.sln
+    
+    - name: Build Solution
+      run: |
+        msbuild RFHUtil.sln `
+          /p:Configuration=${{ matrix.configuration }} `
+          /p:Platform=${{ matrix.platform }} `
+          /m `
+          /v:minimal
+    
+    - name: Run Unit Tests
+      if: matrix.configuration == 'Debug'
+      run: |
+        bin\tests\UnitTests.exe --gtest_output=xml:test-results.xml
+    
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: rfhutil-${{ matrix.platform }}-${{ matrix.configuration }}
+        path: |
+          bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.exe
+          bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
+        retention-days: 30
+    
+    - name: Create Release Assets
+      if: github.event_name == 'release' && matrix.configuration == 'Release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          bin/${{ matrix.platform }}/Release/*.exe
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  code-quality:
+    name: Code Quality Checks
+    runs-on: windows-2022
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Run CodeQL Analysis
+      uses: github/codeql-action/init@v3
+      with:
+        languages: cpp
+    
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+    
+    - name: Build for Analysis
+      run: msbuild RFHUtil.sln /p:Configuration=Release /p:Platform=Win32
+    
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+```
+
+#### Effort Estimate
+- **Workflow creation:** 4 hours
+- **Testing and refinement:** 4 hours
+- **Documentation:** 2 hours
+- **Total:** 10 hours (1-2 days)
+
+---
+
+## 3. MEDIUM TERM: Code Quality (P2)
+
+### 3.1 Unit Testing Framework
+
+**Status:** ✅ DONE — 132 tests across 5 modules using Google Test (Win32 + x64).
+
+---
+
+### 3.2 Refactor DataArea Class
+
+**Problem:** `DataArea` is a massive monolith (~18,000 lines). Hard to maintain, test, and extend.
+
+**Solution:** Break into focused, single-responsibility classes.
+
+#### Proposed Structure
+
+- `MQConnection` — connection lifecycle, heartbeat, reconnect
+- `MQMessageReader` — MQGET, browse, message parsing
+- `MQMessageWriter` — MQPUT, put1
+- `RFHHeaders` — RFH1/RFH2 build/parse
+- `MessageData` — data area, encoding, display formatting
+
+#### Effort Estimate
+- **Analysis:** 8 hours
+- **Refactoring:** 80 hours
+- **Testing:** 40 hours
+- **Total:** ~128 hours (3-4 weeks)
+
+---
+
+## 4. Implementation Timeline
+
+### Phase 1: Quick Wins ✅ COMPLETE
+- P0.1 HeartBeat/KeepAlive
+- P0.2 Auto-Reconnect
+- P0.3 Connection Settings Tab
+- P1.1 VS 2022
+- P1.2 Dark Mode
+- P1.3 64-bit Support
+- P1.4 Unit Testing
+- P2.1 Connection Health Monitor
+- P2.2 Secure Credential Storage
+- P2.3 Editable Data Tab
+
+### Phase 2: CI/CD (Next)
+- GitHub Actions workflow (Win32 + x64, Debug + Release)
+- Automated test runs on PR
+- Release artifact upload
+
+### Phase 3: Refactoring (Month 3-6)
+- DataArea decomposition
+- Modern C++ features (RAII, smart pointers, std::string)
+- Comprehensive test coverage (>70%)
+
+---
+
+## 5. Success Metrics
+
+### Connection Reliability
+- **Before:** 300s failure detection, frequent manual reconnects
+- **After:** 60s failure detection, automatic reconnection + proactive health monitoring
+- **Status:** ✅ Achieved
+
+### Build System
+- **Before:** Manual builds, no automation
+- **After:** Automated builds on every commit
+- **Target:** 100% automated build success rate
+
+### Code Quality
+- **Before:** No tests, high regression risk
+- **After:** 132 unit tests, integration tests
+- **Target:** >70% code coverage
+
+---
+
+## 6. Risk Mitigation
+
+### Technical Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Breaking changes in VS 2022 | Low | Medium | Thorough testing, gradual rollout |
+| MQ compatibility issues | Low | High | Test with multiple MQ versions |
+| Performance regression | Low | Medium | Performance testing, benchmarks |
+| User resistance to changes | Medium | Low | Clear communication, training |
+
+---
+
+**Document Version:** 1.1  
+**Date:** 2026-04-08  
+**Status:** Active

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -32,11 +32,23 @@
 
 | Priority | Item | Effort | Impact | Target Quarter |
 |----------|------|--------|--------|----------------|
-| 🟢 **P2** | Refactor DataArea Class | High | High | Q3 2026 |
-| 🟢 **P2** | Modern C++ Features | High | Medium | Q3 2026 |
-| 🔵 **P3** | CMake Build System | Medium | Low | Q3 2026 |
-| 🔵 **P3** | Comprehensive Testing | High | High | Q3 2026 |
-| 🟡 **P4** | GitHub Actions CI/CD | Medium | High | Q4 2026 |
+| 🔴 **P3.1** | Fix hardcoded MQ SDK paths | Small | High | Q2 2026 |
+| 🟡 **P3.2** | GitHub Actions — build + unit tests | Small | High | Q2 2026 |
+| 🟡 **P3.3** | Expand tests — header parsing (RFH1/RFH2, DLQ, CICS, IMS) | Medium | High | Q2 2026 |
+| 🟡 **P3.4** | Expand tests — message encoding (EBCDIC, hex, JSON, XML) | Medium | High | Q2 2026 |
+| 🟡 **P3.5** | Expand tests — connection lifecycle | Medium | Medium | Q2 2026 |
+| 🟡 **P3.6** | Expand tests — file I/O round-trips | Medium | Medium | Q3 2026 |
+| 🟢 **P3.7** | MQ handle RAII wrapper | Small | Medium | Q3 2026 |
+| 🟢 **P3.8** | Human-readable MQ error messages | Small | Medium | Q3 2026 |
+| 🟢 **P3.9** | TLS configuration improvements | Medium | Medium | Q3 2026 |
+| 🟢 **P3.10** | GitHub Actions — release artifact publishing | Small | Medium | Q3 2026 |
+| 🔵 **P4.1** | DataArea refactor — extract `MQConnection` | Medium | High | Q3 2026 |
+| 🔵 **P4.2** | DataArea refactor — extract `MQMessageReader` / `MQMessageWriter` | High | High | Q3 2026 |
+| 🔵 **P4.3** | DataArea refactor — extract `RFHHeaders` | High | High | Q4 2026 |
+| 🔵 **P4.4** | DataArea refactor — extract `FileHandler` | Medium | High | Q4 2026 |
+| 🔵 **P4.5** | Replace `char[]` buffers with `std::string` | High | Medium | Q4 2026 |
+| 🔵 **P4.6** | Replace manual `new`/`delete` with smart pointers | High | Medium | Q4 2026 |
+| ⚪ **P5** | CMake build system | Medium | Low | 2027 |
 
 ---
 
@@ -48,449 +60,125 @@ This document provides a **detailed, actionable roadmap** for modernizing the mq
 
 ## Priority Matrix
 
-### Immediate Impact (Do First - Weeks 1-4)
+### Phase 1: Foundation ✅ COMPLETE
 
 | Priority | Item | Effort | Impact | Risk | Status |
 |----------|------|--------|--------|------|--------|
 | 🔴 **P0.1** | Add HeartBeat/KeepAlive | Low | High | Low | ✅ DONE |
 | 🔴 **P0.2** | Implement Auto-Reconnect | Medium | High | Low | ✅ DONE |
-| 🔴 **P0.3** | Add tab to enable auto-reconnect and heartbeat/keepalive | Medium | High | Low | ✅ DONE |
+| 🔴 **P0.3** | Connection Settings UI Tab | Medium | High | Low | ✅ DONE |
 | 🟡 **P1.1** | Upgrade to VS 2022 | Low | Medium | Low | ✅ DONE |
 | 🟡 **P1.2** | Dark mode | Low | Medium | Low | ✅ DONE |
 | 🟡 **P1.2b** | Safe mode (browse-only build) | Low | High | Low | ✅ DONE |
-
-
-### Short Term (Weeks 5-12)
-
-| Priority | Item | Effort | Impact | Risk | Status |
-|----------|------|--------|--------|------|--------|
+| 🟡 **P1.3** | 64-bit Support | Medium | High | Low | ✅ DONE |
 | 🟡 **P1.4** | Basic Unit Testing | Medium | High | Low | ✅ DONE |
 | 🟢 **P2.1** | Connection Health Monitor | Medium | Medium | Low | ✅ DONE |
 | 🟢 **P2.2** | Secure Credential Storage | Medium | High | Medium | ✅ DONE |
-| 🟢 **P2.3** | Make the Data tab editable by adding a check mark and allow for that data to be written to the queue | Medium | Medium | Medium | ✅ DONE |
+| 🟢 **P2.3** | Editable Data Tab | Medium | Medium | Medium | ✅ DONE |
 
-### Medium Term (Months 4-6)
+### Phase 2: CI/CD & Test Coverage (P3) — Next Up
 
-| Priority | Item | Effort | Impact | Risk |
-|----------|------|--------|--------|------|
-| 🟢 **P2** | Refactor DataArea Class | High | High | Medium |
-| 🟢 **P2** | Modern C++ Features | High | Medium | Medium |
-| 🔵 **P3** | CMake Build System | Medium | Low | Medium |
-| 🔵 **P3** | Comprehensive Testing | High | High | Low |
-| 🟡 **P4** | Add GitHub Actions CI/CD | Medium | High | Low |
+| Priority | Item | Effort | Impact | Risk | Notes |
+|----------|------|--------|--------|------|-------|
+| 🔴 **P3.1** | Fix hardcoded MQ SDK paths | Small | High | Low | Replace `d:\apps\mq\` with `$(MQ_HOME)` env var in all .vcxproj files |
+| 🟡 **P3.2** | GitHub Actions — build + unit tests | Small | High | Low | Windows runner, Win32+x64 matrix, Google Test output |
+| 🟡 **P3.3** | Expand tests — header parsing | Medium | High | Low | RFH1, RFH2, DLQ, CICS, IMS header build/parse coverage |
+| 🟡 **P3.4** | Expand tests — message encoding | Medium | High | Low | EBCDIC, hex, JSON, XML round-trips |
+| 🟡 **P3.5** | Expand tests — connection lifecycle | Medium | Medium | Low | Connect, disconnect, reconnect, health check state |
+| 🟡 **P3.6** | Expand tests — file I/O | Medium | Medium | Low | Read/write various formats, round-trip correctness |
+| 🟢 **P3.7** | MQ handle RAII wrapper | Small | Medium | Low | Wrap `MQHOBJ`/`MQHCONN` — prevents leaks on exception paths |
+| 🟢 **P3.8** | Human-readable MQ error messages | Small | Medium | Low | Map reason codes (e.g. RC=2035) to descriptive strings |
+| 🟢 **P3.9** | TLS configuration improvements | Medium | Medium | Medium | Make cipher suite configurable per connection in UI |
+| 🟢 **P3.10** | GitHub Actions — release publishing | Small | Medium | Low | Upload `.exe` artifacts on tag; depends on P3.2 |
 
----
+### Phase 3: Refactoring (P4) — Requires P3 Safety Net
 
-## 1. IMMEDIATE: Connection Reliability (P0)
+| Priority | Item | Effort | Impact | Risk | Notes |
+|----------|------|--------|--------|------|-------|
+| 🔵 **P4.1** | DataArea — extract `MQConnection` | Medium | High | Medium | Connection lifecycle, heartbeat, reconnect — smallest safe first cut |
+| 🔵 **P4.2** | DataArea — extract `MQMessageReader` / `MQMessageWriter` | High | High | Medium | MQGET/browse and MQPUT/put1 — depends on P4.1 |
+| 🔵 **P4.3** | DataArea — extract `RFHHeaders` | High | High | Medium | RFH1/RFH2/DLQ/CICS/IMS parse & build |
+| 🔵 **P4.4** | DataArea — extract `FileHandler` | Medium | High | Medium | File read/write in all supported formats |
+| 🔵 **P4.5** | Replace `char[]` with `std::string` | High | Medium | Medium | Start with non-MQ-API paths; incremental |
+| 🔵 **P4.6** | Replace `new`/`delete` with smart pointers | High | Medium | Medium | Start with DataArea internals after P4.1–P4.4 |
 
-### 1.1 Add HeartBeat and KeepAlive Configuration
+### Phase 4: Long-term (P5)
 
-**Problem:** Current code doesn't set these, leading to slow failure detection and firewall timeouts.
-
-**Solution:** Add explicit configuration in connection setup.
-
-#### Implementation Steps
-
-**Step 1: Locate the connection code**
-- File: [`RFHUtil/DataArea.cpp`](RFHUtil/DataArea.cpp:10350-10450)
-- Method: `DataArea::connect2QM()`
-- Line: After 10407 (after `cd.MaxMsgLength = 104857600;`)
-
-**Step 2: Add the configuration**
-
-```cpp
-// File: RFHUtil/DataArea.cpp
-// Location: After line 10407
-
-// ============================================================
-// MODERNIZATION: Add HeartBeat and KeepAlive configuration
-// ============================================================
-
-// Set HeartBeat interval for fast MQ-level failure detection
-// This detects queue manager crashes, process failures, and keeps
-// the connection active to prevent firewall timeouts
-cd.HeartBeatInterval = 60;  // 60 seconds (vs default 300s)
-
-// Set KeepAlive interval for network-level failure detection
-// This detects network cable unplugs, router failures, and
-// "half-open" TCP connections
-cd.KeepAliveInterval = MQKAI_AUTO;  // Use OS defaults
-
-// For environments with aggressive firewalls (5-minute timeout):
-// cd.KeepAliveInterval = 30;  // 30 seconds
-
-// Ensure we're using a version that supports these fields
-if (cd.Version < MQCD_VERSION_7) {
-    cd.Version = MQCD_VERSION_7;
-    cd.StrucLength = MQCD_LENGTH_7;
-}
-
-// Add trace logging
-if (traceEnabled) {
-    sprintf(traceInfo, "HeartBeat=%d, KeepAlive=%d", 
-            cd.HeartBeatInterval, cd.KeepAliveInterval);
-    logTraceEntry(traceInfo);
-}
-```
-
-**Step 3: Test the changes**
-
-```cpp
-// Test scenarios:
-// 1. Normal connection - verify heartbeats are sent
-// 2. Network disconnect - verify fast detection
-// 3. QM crash - verify fast detection
-// 4. Long idle period - verify no firewall timeout
-```
-
-#### Expected Outcomes
-
-**Before:**
-- Failure detection: 300+ seconds (5+ minutes)
-- Firewall timeouts: Common after 5 minutes idle
-- User experience: Poor (long waits, manual reconnects)
-
-**After:**
-- Failure detection: 60 seconds (5x faster)
-- Firewall timeouts: Eliminated (heartbeats keep connection alive)
-- User experience: Excellent (fast detection, automatic recovery)
-
-#### Effort Estimate
-- **Development:** 1 hour
-- **Testing:** 2 hours
-- **Documentation:** 1 hour
-- **Total:** 4 hours
+| Priority | Item | Effort | Impact | Risk | Notes |
+|----------|------|--------|--------|------|-------|
+| ⚪ **P5** | CMake build system | Medium | Low | Low | Cross-platform support; nice-to-have |
 
 ---
 
-### 1.2 Implement Automatic Reconnection
+## Implementation Timeline
 
-**Problem:** When connection fails, user must manually reconnect. Poor user experience.
+### Phase 1: Foundation ✅ COMPLETE
+All P0–P2 items shipped. Key deliverables: heartbeat/reconnect, dark mode, safe mode, 64-bit, unit testing, health monitor, DPAPI credentials, editable data tab.
 
-**Solution:** Add automatic reconnection with exponential backoff.
+### Phase 2: CI/CD & Coverage (Q2–Q3 2026)
+1. **P3.1** — Parameterize MQ SDK paths (unblocks CI and other contributors)
+2. **P3.2** — GitHub Actions basic workflow
+3. **P3.3–P3.6** — Expand test coverage to core logic areas
+4. **P3.7–P3.10** — Smaller quality improvements in parallel
 
-#### Implementation Steps
+### Phase 3: Refactoring (Q3–Q4 2026)
+With CI/CD and tests as safety net:
+1. **P4.1** — Extract `MQConnection` first (smallest, most self-contained)
+2. **P4.2–P4.4** — Extract remaining DataArea responsibilities iteratively
+3. **P4.5–P4.6** — Modernize memory/string management incrementally
 
-**Step 1: Create ConnectionManager class**
-
-Create new file: `RFHUtil/ConnectionManager.h`
-
-```cpp
-/*
- * ConnectionManager.h
- * Manages MQ connections with automatic reconnection
- */
-
-#ifndef CONNECTION_MANAGER_H
-#define CONNECTION_MANAGER_H
-
-#include "cmqc.h"
-#include <string>
-
-class ConnectionManager {
-public:
-    // Configuration
-    struct Config {
-        int maxRetries = 3;
-        int initialDelayMs = 1000;      // 1 second
-        int maxDelayMs = 30000;         // 30 seconds
-        double backoffMultiplier = 2.0; // Exponential backoff
-        bool enableAutoReconnect = true;
-    };
-
-    ConnectionManager();
-    ~ConnectionManager();
-
-    // Connection management
-    bool connect(const char* qmName, const Config& config = Config());
-    bool disconnect();
-    bool isConnected() const;
-    bool ensureConnected();  // Check and reconnect if needed
-
-    // Health monitoring
-    bool isHealthy();
-    MQLONG getLastCompletionCode() const { return lastCC; }
-    MQLONG getLastReasonCode() const { return lastRC; }
-    const char* getLastError() const { return lastError.c_str(); }
-
-    // Connection handle
-    MQHCONN getHandle() const { return qm; }
-
-private:
-    MQHCONN qm;
-    bool connected;
-    std::string currentQM;
-    Config config;
-    
-    // Error tracking
-    MQLONG lastCC;
-    MQLONG lastRC;
-    std::string lastError;
-    
-    // Reconnection state
-    int reconnectAttempts;
-    DWORD lastReconnectTime;
-
-    // Internal methods
-    bool connectInternal(const char* qmName);
-    bool reconnect();
-    int calculateBackoffDelay(int attempt);
-    void logConnectionEvent(const char* event);
-};
-
-#endif // CONNECTION_MANAGER_H
-```
-
-**Step 2: Integrate with DataArea**
-
-Modify `RFHUtil/DataArea.h`:
-
-```cpp
-// Add to DataArea class
-private:
-    ConnectionManager* connMgr;  // New connection manager
-
-public:
-    // Add new methods
-    bool connectWithRetry(const char* qmName);
-    bool ensureConnection();
-```
-
-#### Effort Estimate
-- **Development:** 8 hours
-- **Testing:** 4 hours
-- **Integration:** 4 hours
-- **Documentation:** 2 hours
-- **Total:** 18 hours (2-3 days)
+### Phase 4: Long-term (2027+)
+- CMake for cross-platform build support
 
 ---
 
-## 2. SHORT TERM: Build System Modernization (P1)
+## Key Findings from Codebase Analysis (April 2026)
 
-### 2.1 Upgrade to Visual Studio 2022
+### DataArea Monolith
+- **DataArea.cpp**: 25,881 lines | **DataArea.h**: 1,091 lines
+- 243+ public/protected methods covering: MQ connections, queue ops, message parsing, file I/O, data transformation, header management, pub/sub, PCF requests
+- 132 raw `new`/`delete` operations; ~1,573 instances of `char*`, `sprintf`, `strcpy`, `malloc`, `free` across the codebase
+- Zero `std::string`, zero smart pointers
 
-**Status:** ✅ DONE — Already using VS 2022 (v143) with Windows SDK 10.0.
+### Test Coverage Gaps
+- 132 existing tests cover utility functions only (encoding, XML/JSON parsing, string utils, names)
+- **Zero tests** for DataArea, header building, connection lifecycle, queue operations, file I/O, pub/sub, PCF
 
----
+### CI/CD Blockers
+- MQ SDK paths hardcoded to `d:\apps\mq\` in all .vcxproj files
+- No `.github/workflows/` directory exists
+- Unit tests (non-MQ) can run in CI immediately once paths are parameterized
 
-### 2.2 Add 64-bit Support
-
-**Status:** ✅ DONE — x64 platform configuration added, 32 files fixed.
-
----
-
-### 2.3 Implement GitHub Actions CI/CD
-
-**Problem:** No automated builds or testing. Manual release process.
-
-**Solution:** Add GitHub Actions for automated CI/CD.
-
-#### Implementation Steps
-
-**Step 1: Create Workflow File**
-
-Create `.github/workflows/build-and-test.yml`:
-
-```yaml
-name: Build and Test
-
-on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main ]
-  release:
-    types: [ created ]
-
-env:
-  MQ_VERSION: 9.3.0.0
-
-jobs:
-  build:
-    name: Build ${{ matrix.platform }} ${{ matrix.configuration }}
-    runs-on: windows-2022
-    
-    strategy:
-      matrix:
-        platform: [Win32, x64]
-        configuration: [Release, Debug]
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
-    
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v2
-    
-    - name: Cache MQ Installation
-      id: cache-mq
-      uses: actions/cache@v4
-      with:
-        path: C:\Program Files\IBM\MQ
-        key: mq-${{ env.MQ_VERSION }}-${{ matrix.platform }}
-    
-    - name: Install IBM MQ Client
-      if: steps.cache-mq.outputs.cache-hit != 'true'
-      run: |
-        # Download and install MQ client
-        echo "Installing MQ Client..."
-    
-    - name: Restore NuGet packages
-      run: nuget restore RFHUtil.sln
-    
-    - name: Build Solution
-      run: |
-        msbuild RFHUtil.sln `
-          /p:Configuration=${{ matrix.configuration }} `
-          /p:Platform=${{ matrix.platform }} `
-          /m `
-          /v:minimal
-    
-    - name: Run Unit Tests
-      if: matrix.configuration == 'Debug'
-      run: |
-        bin\tests\UnitTests.exe --gtest_output=xml:test-results.xml
-    
-    - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: rfhutil-${{ matrix.platform }}-${{ matrix.configuration }}
-        path: |
-          bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.exe
-          bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
-        retention-days: 30
-    
-    - name: Create Release Assets
-      if: github.event_name == 'release' && matrix.configuration == 'Release'
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          bin/${{ matrix.platform }}/Release/*.exe
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  code-quality:
-    name: Code Quality Checks
-    runs-on: windows-2022
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Run CodeQL Analysis
-      uses: github/codeql-action/init@v3
-      with:
-        languages: cpp
-    
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
-    
-    - name: Build for Analysis
-      run: msbuild RFHUtil.sln /p:Configuration=Release /p:Platform=Win32
-    
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-```
-
-#### Effort Estimate
-- **Workflow creation:** 4 hours
-- **Testing and refinement:** 4 hours
-- **Documentation:** 2 hours
-- **Total:** 10 hours (1-2 days)
+### Modern C++ Status
+- 0% adoption of modern C++ idioms
+- Full MFC dependency for UI (CString, CDialog — not replaceable short-term)
+- Memory management entirely manual; no RAII outside of MFC
 
 ---
 
-## 3. MEDIUM TERM: Code Quality (P2)
+## Success Metrics
 
-### 3.1 Unit Testing Framework
-
-**Status:** ✅ DONE — 132 tests across 5 modules using Google Test (Win32 + x64).
-
----
-
-### 3.2 Refactor DataArea Class
-
-**Problem:** `DataArea` is a massive monolith (~18,000 lines). Hard to maintain, test, and extend.
-
-**Solution:** Break into focused, single-responsibility classes.
-
-#### Proposed Structure
-
-- `MQConnection` — connection lifecycle, heartbeat, reconnect
-- `MQMessageReader` — MQGET, browse, message parsing
-- `MQMessageWriter` — MQPUT, put1
-- `RFHHeaders` — RFH1/RFH2 build/parse
-- `MessageData` — data area, encoding, display formatting
-
-#### Effort Estimate
-- **Analysis:** 8 hours
-- **Refactoring:** 80 hours
-- **Testing:** 40 hours
-- **Total:** ~128 hours (3-4 weeks)
+| Area | Before | Target |
+|------|--------|--------|
+| Test coverage | 132 tests, utility-only | 400+ tests, core logic covered |
+| CI/CD | None | Automated builds + tests on every PR |
+| DataArea size | 26k lines, 1 class | 5–6 focused classes, <5k lines each |
+| Memory safety | Manual new/delete everywhere | Smart pointers, RAII handles |
+| Build portability | Hardcoded local paths | `$(MQ_HOME)` env var, buildable by any contributor |
 
 ---
 
-## 4. Implementation Timeline
-
-### Phase 1: Quick Wins ✅ COMPLETE
-- P0.1 HeartBeat/KeepAlive
-- P0.2 Auto-Reconnect
-- P0.3 Connection Settings Tab
-- P1.1 VS 2022
-- P1.2 Dark Mode
-- P1.3 64-bit Support
-- P1.4 Unit Testing
-- P2.1 Connection Health Monitor
-- P2.2 Secure Credential Storage
-- P2.3 Editable Data Tab
-
-### Phase 2: CI/CD (Next)
-- GitHub Actions workflow (Win32 + x64, Debug + Release)
-- Automated test runs on PR
-- Release artifact upload
-
-### Phase 3: Refactoring (Month 3-6)
-- DataArea decomposition
-- Modern C++ features (RAII, smart pointers, std::string)
-- Comprehensive test coverage (>70%)
-
----
-
-## 5. Success Metrics
-
-### Connection Reliability
-- **Before:** 300s failure detection, frequent manual reconnects
-- **After:** 60s failure detection, automatic reconnection + proactive health monitoring
-- **Status:** ✅ Achieved
-
-### Build System
-- **Before:** Manual builds, no automation
-- **After:** Automated builds on every commit
-- **Target:** 100% automated build success rate
-
-### Code Quality
-- **Before:** No tests, high regression risk
-- **After:** 132 unit tests, integration tests
-- **Target:** >70% code coverage
-
----
-
-## 6. Risk Mitigation
-
-### Technical Risks
+## Risk Mitigation
 
 | Risk | Probability | Impact | Mitigation |
 |------|-------------|--------|------------|
-| Breaking changes in VS 2022 | Low | Medium | Thorough testing, gradual rollout |
-| MQ compatibility issues | Low | High | Test with multiple MQ versions |
-| Performance regression | Low | Medium | Performance testing, benchmarks |
-| User resistance to changes | Medium | Low | Clear communication, training |
+| DataArea refactor introduces regressions | Medium | High | Expand tests first (P3.3–P3.6), CI gate (P3.2) |
+| MQ SDK unavailable in CI | High | Medium | Skip MQ-dependent tests in CI; unit tests only |
+| Breaking changes during modernization | Low | Medium | Incremental extraction, one class at a time |
+| MQ API incompatibility with C++ wrappers | Low | High | Keep MQ API calls isolated; wrap at boundary only |
 
 ---
 
-**Document Version:** 1.1  
-**Date:** 2026-04-08  
+**Document Version:** 1.2
+**Date:** 2026-04-13
 **Status:** Active

--- a/RFHUtil/RFHUtil.vcxproj
+++ b/RFHUtil/RFHUtil.vcxproj
@@ -78,8 +78,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\Release\</OutDir>
-    <IncludePath>d:\apps\mq\tools\c\include;$(IncludePath)</IncludePath>
-    <LibraryPath>d:\apps\mq\bin64;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MQ_HOME)\tools\c\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(MQ_HOME)\bin64;$(LibraryPath)</LibraryPath>
     <TargetName>rfhutil</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -89,8 +89,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\Release\x64\</OutDir>
-    <IncludePath>d:\apps\mq\tools\c\include;$(IncludePath)</IncludePath>
-    <LibraryPath>d:\apps\mq\tools\lib64;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(MQ_HOME)\tools\c\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(MQ_HOME)\tools\lib64;$(LibraryPath)</LibraryPath>
     <TargetName>rfhutil</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -99,7 +99,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;_DEBUG;_WIN32_WINNT 0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -126,7 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -153,7 +153,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_WIN64;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;_DEBUG;_WIN32_WINNT 0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -180,7 +180,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_WIN64;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -189,7 +189,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)rfhutil$(TargetExt)</OutputFile>
-      <AdditionalLibraryDirectories>d:\apps\mq\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MQ_HOME)\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>

--- a/docs/ARCHITECTURE_ANALYSIS.md
+++ b/docs/ARCHITECTURE_ANALYSIS.md
@@ -1,0 +1,942 @@
+# RFHUtil Project - Architecture & Modernization Analysis
+
+## Executive Summary
+
+This document provides a comprehensive analysis of the mq-rfhutil project, covering:
+1. **Architecture and Code Organization**
+2. **Modernization Opportunities**
+3. **Connection Management & Channel Keepalive Analysis**
+
+---
+
+## 1. Architecture and Code Organization
+
+### 1.1 Project Structure
+
+```
+mq-rfhutil/
+├── RFHUtil/          # Main GUI application (MFC-based)
+├── Client/           # Client variant build configuration
+├── mqperf/           # Performance testing tools suite
+├── bin/Release/      # Pre-built executables
+└── Documentation/    # User guides (ih03.pdf, ih03.doc)
+```
+
+### 1.2 Technology Stack
+
+| Component | Technology |
+|-----------|-----------|
+| **Language** | C++ |
+| **GUI Framework** | Microsoft Foundation Classes (MFC) |
+| **Build System** | Visual Studio 2017 (v141 toolset) |
+| **Platform** | Windows 32-bit (Win32) |
+| **SDK** | Windows 10 SDK (10.0.17134.0) |
+| **MQ Integration** | IBM MQ Client/Server libraries (mqm.dll) |
+| **Version** | 9.1.6 (Build 233, October 2021) |
+
+### 1.3 Core Components
+
+#### Main Application (RFHUtil)
+
+**Document-View Architecture (MFC Pattern)**
+
+```
+rfhutilApp (Application)
+    ├── MainFrm (Main Window Frame)
+    ├── rfhutilDoc (Document - Data Model)
+    ├── rfhutilView (View - UI Presentation)
+    └── DataArea (Core Business Logic & MQ Operations)
+```
+
+**Key Classes and Responsibilities:**
+
+1. **DataArea** ([`DataArea.cpp`](RFHUtil/DataArea.cpp:1), [`DataArea.h`](RFHUtil/DataArea.h:1))
+   - Central data management class (~23,000+ lines)
+   - MQ connection management
+   - Queue operations (MQOPEN, MQGET, MQPUT, MQCLOSE)
+   - Message parsing and formatting
+   - File I/O operations
+   - Pub/Sub operations
+
+2. **General** ([`General.cpp`](RFHUtil/General.cpp:1), [`General.h`](RFHUtil/General.h:1))
+   - Main property page
+   - Queue manager and queue selection
+   - Connection parameters
+   - User interface controls
+
+3. **MQMD Page** ([`MQMDPAGE.cpp`](RFHUtil/MQMDPAGE.cpp:1))
+   - MQ Message Descriptor editing
+   - Message properties configuration
+
+4. **Message Format Handlers:**
+   - **RFH** ([`RFH.cpp`](RFHUtil/RFH.cpp:1)) - RFH/RFH2 header processing
+   - **CICS** ([`CICS.cpp`](RFHUtil/CICS.cpp:1)) - CICS header support
+   - **IMS** ([`Ims.cpp`](RFHUtil/Ims.cpp:1)) - IMS header support
+   - **DLQ** ([`Dlq.cpp`](RFHUtil/Dlq.cpp:1)) - Dead Letter Queue header
+   - **JMS** ([`jms.cpp`](RFHUtil/jms.cpp:1)) - JMS message support
+   - **PubSub** ([`PubSub.cpp`](RFHUtil/PubSub.cpp:1)) - Pub/Sub operations
+
+5. **Utility Classes:**
+   - **comsubs** ([`comsubs.cpp`](RFHUtil/comsubs.cpp:1)) - Common subroutines (encoding, time, memory)
+   - **mqsubs** ([`mqsubs.cpp`](RFHUtil/mqsubs.cpp:1)) - MQ-specific utilities
+   - **Copybook** ([`Copybook.cpp`](RFHUtil/Copybook.cpp:1)) - COBOL copybook parsing
+   - **JsonParse** ([`JsonParse.cpp`](RFHUtil/JsonParse.cpp:1)) - JSON parsing
+
+#### Performance Testing Tools (mqperf)
+
+Independent command-line tools for MQ performance testing:
+
+| Tool | Purpose |
+|------|---------|
+| **mqcapone** | Capture single message |
+| **mqcapsub** | Capture subscription messages |
+| **mqcapture** | General message capture |
+| **mqlatency** | Measure message latency |
+| **mqput2** | Put messages with timing |
+| **mqputs** | Bulk message puts |
+| **mqreply** | Request/reply testing |
+| **mqtest** | General MQ testing |
+| **mqtimes** (1-3) | Various timing tests |
+
+**Common Subroutines** ([`mqperf/CommonSubs/`](mqperf/CommonSubs/)):
+- [`comsubs.c`](mqperf/CommonSubs/comsubs.c:1) - Common utilities
+- [`qsubs.c`](mqperf/CommonSubs/qsubs.c:1) - Queue operations
+- [`rfhsubs.c`](mqperf/CommonSubs/rfhsubs.c:1) - RFH handling
+- [`timesubs.c`](mqperf/CommonSubs/timesubs.c:1) - Timing utilities
+
+### 1.4 Build Configurations
+
+**Two Main Variants:**
+
+1. **rfhutil.exe** - Server bindings (local queue manager)
+   - Links directly to MQ server libraries
+   - Faster performance for local QM access
+   - No network overhead
+
+2. **rfhutilc.exe** - Client connections (remote queue manager)
+   - Uses MQ client libraries
+   - Connects via channels (TCP/IP, etc.)
+   - Supports SSL/TLS
+   - Controlled by `MQCLIENT` preprocessor directive
+
+---
+
+## 2. Connection Management & Channel Keepalive Analysis
+
+### 2.1 Connection Architecture
+
+**Connection Flow:**
+
+```mermaid
+graph TD
+    A[User Initiates Connection] --> B{Already Connected?}
+    B -->|Yes, Same QM| C[Return Success]
+    B -->|Yes, Different QM| D[Disconnect Current]
+    B -->|No| E[Build MQCNO Structure]
+    D --> E
+    E --> F[Configure MQCD Channel Definition]
+    F --> G[Set Authentication MQCSP]
+    G --> H{SSL Enabled?}
+    H -->|Yes| I[Configure MQSCO SSL Options]
+    H -->|No| J[Call MQCONNX]
+    I --> J
+    J --> K{Success?}
+    K -->|Yes| L[Store Connection Handle]
+    K -->|No| M[Set Error Message]
+    L --> N[Query QM Properties]
+    N --> O[Connection Complete]
+```
+
+### 2.2 Connection Implementation Details
+
+**Key Code Location:** [`DataArea::connect2QM()`](RFHUtil/DataArea.cpp:10350-10850)
+
+**Connection Structures Used:**
+
+1. **MQCNO** (Connection Options) - Version 2/5
+   ```cpp
+   cno.Version = MQCNO_VERSION_2;
+   cno.Options = MQCNO_HANDLE_SHARE_NO_BLOCK;
+   cno.ClientConnPtr = &cd;
+   cno.SecurityParmsPtr = &csp; // If using CSP
+   ```
+
+2. **MQCD** (Channel Definition) - Version 4/7
+   ```cpp
+   cd.Version = MQCD_VERSION_4;
+   cd.MaxMsgLength = 104857600; // 100MB
+   cd.TransportType = MQXPT_TCP; // or other
+   ```
+
+3. **MQCSP** (Security Parameters) - For authentication
+   ```cpp
+   csp.AuthenticationType = MQCSP_AUTH_USER_ID_AND_PWD;
+   csp.CSPUserIdPtr = userid;
+   csp.CSPPasswordPtr = password;
+   ```
+
+4. **MQSCO** (SSL Configuration) - For TLS/SSL
+   ```cpp
+   sco.KeyRepository = ssl_keyr;
+   cd.SSLCipherSpec = cipher_spec;
+   cd.SSLClientAuth = MQSCA_REQUIRED/OPTIONAL;
+   ```
+
+### 2.3 Channel Keepalive & Reconnection Analysis
+
+#### ⚠️ **CRITICAL FINDINGS:**
+
+**1. NO Automatic Reconnection Logic**
+- The application does **NOT** implement automatic reconnection
+- If connection is lost, user must manually reconnect
+- No retry mechanism for transient network failures
+
+**2. NO Explicit Keepalive Configuration**
+- The code does **NOT** set `HeartBeatInterval` in MQCD
+- The code does **NOT** set `KeepAliveInterval` in MQCD
+- Relies on **default MQ channel settings**
+
+**3. Connection State Management**
+```cpp
+// From DataArea.h
+MQHCONN qm;              // Queue manager handle
+bool connected;          // Connection state flag
+CString currentQM;       // Current QM name
+```
+
+**4. What IS Configured:**
+
+| Parameter | Value | Location |
+|-----------|-------|----------|
+| `cd.Version` | MQCD_VERSION_4 (or 7 for SSL) | Line 10403 |
+| `cd.MaxMsgLength` | 104857600 (100MB) | Line 10407 |
+| `cd.TransportType` | MQXPT_TCP (from MQSERVER) | Line 10699 |
+| `cd.ChannelName` | From MQSERVER env var | Line 10684-10689 |
+| `cd.ConnectionName` | From MQSERVER env var | Line 10692-10696 |
+| `cd.SSLCipherSpec` | User-specified | Line 10537-10538 |
+| `cd.SSLClientAuth` | REQUIRED/OPTIONAL | Line 10544/10549 |
+| `cd.SecurityExit` | User-specified | Line 10493 |
+| `cd.LocalAddress` | User-specified | Line 10711 |
+
+**5. What is NOT Configured:**
+
+❌ `cd.HeartBeatInterval` - Not set (uses QM default, typically 300 seconds)
+❌ `cd.KeepAliveInterval` - Not set (uses system TCP keepalive)
+❌ Automatic reconnection logic
+❌ Connection health monitoring
+❌ Retry on connection failure
+
+### 2.4 Connection Lifecycle
+
+**Connection Establishment:**
+```cpp
+// DataArea.cpp:10752
+XMQConnX(qmPtr, &cno, &qm, &cc, &rc);
+```
+
+**Disconnection:**
+```cpp
+// DataArea.cpp (discQM method)
+XMQDisc(&qm, &cc, &rc);
+connected = false;
+qm = NULL;
+```
+
+**Connection Validation:**
+- Checks if already connected to same QM before reconnecting
+- Disconnects from different QM before new connection
+- No periodic health checks
+
+### 2.5 Channel Configuration Sources
+
+**Priority Order:**
+
+1. **MQSERVER Environment Variable**
+   ```
+   MQSERVER=CHANNEL_NAME/TRANSPORT_TYPE/CONNECTION_NAME
+   Example: MQSERVER=SYSTEM.DEF.SVRCONN/TCP/localhost(1414)
+   ```
+
+2. **Client Channel Definition Table (CCDT)**
+   - Location: MQ install directory
+   - Binary file format
+   - Parsed in [`DataArea::loadChannelTable()`](RFHUtil/DataArea.cpp:24992-25015)
+
+3. **User Input via Connection Dialog**
+   - Queue Manager name
+   - User ID / Password
+   - SSL settings
+   - Security exit
+
+---
+
+## 3. Modernization Opportunities
+
+### 3.1 Visual Studio & Build System Upgrade
+
+#### Current State
+- Visual Studio 2017 (v141 toolset)
+- Windows SDK 10.0.17134.0 (2018)
+- 32-bit only (Win32 platform)
+- No CI/CD pipeline
+
+#### Recommended Upgrades
+
+**Priority 1: Visual Studio 2022**
+```xml
+<!-- Update RFHUtil.vcxproj -->
+<PlatformToolset>v143</PlatformToolset>
+<WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+```
+
+**Benefits:**
+- Latest C++ standards (C++20/23)
+- Better IntelliSense and debugging
+- Improved security features
+- Active support and updates
+- Better performance optimizations
+
+**Priority 2: Add 64-bit Support**
+```xml
+<ProjectConfiguration Include="Release|x64">
+  <Configuration>Release</Configuration>
+  <Platform>x64</Platform>
+</ProjectConfiguration>
+```
+
+**Benefits:**
+- Support modern 64-bit systems
+- Access to more memory
+- Better performance on modern hardware
+- Future-proofing
+
+**Priority 3: CMake Build System**
+
+Create `CMakeLists.txt` for cross-platform potential:
+```cmake
+cmake_minimum_required(VERSION 3.20)
+project(mq-rfhutil VERSION 9.1.6)
+
+# Enable modern C++
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# MFC support
+set(CMAKE_MFC_FLAG 1)
+
+# Add executables
+add_executable(rfhutil WIN32 ${RFHUTIL_SOURCES})
+add_executable(rfhutilc WIN32 ${RFHUTIL_SOURCES})
+target_compile_definitions(rfhutilc PRIVATE MQCLIENT)
+```
+
+**Benefits:**
+- Modern build system
+- Better dependency management
+- Easier CI/CD integration
+- Cross-platform potential (with Qt migration)
+
+### 3.2 CI/CD Pipeline Implementation
+
+#### GitHub Actions Workflow
+
+Create `.github/workflows/build.yml`:
+
+```yaml
+name: Build RFHUtil
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-2022
+    
+    strategy:
+      matrix:
+        platform: [Win32, x64]
+        configuration: [Release, Debug]
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+    
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1
+    
+    - name: Restore NuGet packages
+      run: nuget restore RFHUtil.sln
+    
+    - name: Build Solution
+      run: msbuild RFHUtil.sln /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }}
+    
+    - name: Run Tests
+      run: |
+        # Add test execution here
+    
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: rfhutil-${{ matrix.platform }}-${{ matrix.configuration }}
+        path: bin/${{ matrix.configuration }}/
+    
+    - name: Create Release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: bin/Release/*.exe
+```
+
+#### Additional CI/CD Enhancements
+
+1. **Code Quality Checks**
+   - Static analysis (PVS-Studio, Clang-Tidy)
+   - Code coverage reporting
+   - Security scanning (CodeQL)
+
+2. **Automated Testing**
+   - Unit tests (Google Test framework)
+   - Integration tests with MQ Docker containers
+   - UI automation tests
+
+3. **Documentation Generation**
+   - Doxygen for API documentation
+   - Automated changelog generation
+   - Release notes automation
+
+### 3.3 Code Modernization
+
+#### 3.3.1 Connection Management Improvements
+
+**Add Automatic Reconnection:**
+
+```cpp
+class ConnectionManager {
+private:
+    MQHCONN qm;
+    bool connected;
+    int reconnectAttempts;
+    int maxReconnectAttempts = 3;
+    int reconnectDelayMs = 5000;
+    
+public:
+    bool connectWithRetry(const char* qmName) {
+        for (int attempt = 0; attempt < maxReconnectAttempts; attempt++) {
+            if (connect2QM(qmName)) {
+                return true;
+            }
+            
+            if (attempt < maxReconnectAttempts - 1) {
+                logTraceEntry("Connection failed, retrying...");
+                Sleep(reconnectDelayMs);
+            }
+        }
+        return false;
+    }
+    
+    bool ensureConnected() {
+        if (!isHealthy()) {
+            return reconnect();
+        }
+        return true;
+    }
+    
+    bool isHealthy() {
+        // Perform lightweight health check
+        MQLONG cc, rc;
+        MQINQ(qm, ..., &cc, &rc);
+        return (cc == MQCC_OK);
+    }
+};
+```
+
+**Add Keepalive Configuration:**
+
+```cpp
+// In connect2QM method, add:
+cd.HeartBeatInterval = 60;  // 60 seconds (default is 300)
+cd.KeepAliveInterval = MQKAI_AUTO;  // Use system TCP keepalive
+
+// For more aggressive keepalive:
+cd.Version = MQCD_VERSION_11;  // Use latest version
+cd.KeepAliveInterval = 30;  // 30 seconds
+```
+
+**Add Connection Event Handling:**
+
+```cpp
+class ConnectionEventHandler {
+public:
+    virtual void onConnected(const char* qmName) = 0;
+    virtual void onDisconnected(MQLONG reason) = 0;
+    virtual void onConnectionLost() = 0;
+    virtual void onReconnecting(int attempt) = 0;
+    virtual void onReconnected() = 0;
+};
+
+// Implement in DataArea
+void DataArea::monitorConnection() {
+    // Background thread to monitor connection health
+    while (connected) {
+        if (!isHealthy()) {
+            fireEvent(ConnectionEventHandler::onConnectionLost);
+            attemptReconnect();
+        }
+        Sleep(30000);  // Check every 30 seconds
+    }
+}
+```
+
+#### 3.3.2 Modern C++ Features
+
+**Replace Raw Pointers with Smart Pointers:**
+
+```cpp
+// Current:
+char* buffer = (char*)malloc(size);
+// ...
+free(buffer);
+
+// Modern:
+std::unique_ptr<char[]> buffer = std::make_unique<char[]>(size);
+// Automatic cleanup
+```
+
+**Use RAII for MQ Resources:**
+
+```cpp
+class MQConnection {
+    MQHCONN handle;
+public:
+    MQConnection(const char* qmName) {
+        MQCONNX(..., &handle, ...);
+    }
+    
+    ~MQConnection() {
+        if (handle != MQHO_NONE) {
+            MQDISC(&handle, ...);
+        }
+    }
+    
+    // Delete copy, allow move
+    MQConnection(const MQConnection&) = delete;
+    MQConnection& operator=(const MQConnection&) = delete;
+    MQConnection(MQConnection&&) = default;
+    MQConnection& operator=(MQConnection&&) = default;
+};
+```
+
+**Use std::string Instead of CString:**
+
+```cpp
+// Current:
+CString m_qm_name;
+
+// Modern:
+std::string m_qm_name;
+
+// Or for compatibility:
+#ifdef _MFC_VER
+    using String = CString;
+#else
+    using String = std::string;
+#endif
+```
+
+#### 3.3.3 Error Handling Improvements
+
+**Add Structured Error Handling:**
+
+```cpp
+enum class MQErrorCategory {
+    Connection,
+    Queue,
+    Message,
+    Security,
+    Network
+};
+
+class MQException : public std::exception {
+    MQLONG completionCode;
+    MQLONG reasonCode;
+    MQErrorCategory category;
+    std::string message;
+    
+public:
+    MQException(MQLONG cc, MQLONG rc, MQErrorCategory cat, const char* msg)
+        : completionCode(cc), reasonCode(rc), category(cat), message(msg) {}
+    
+    const char* what() const noexcept override {
+        return message.c_str();
+    }
+    
+    bool isRecoverable() const {
+        // Determine if error is recoverable
+        return (reasonCode == MQRC_CONNECTION_BROKEN ||
+                reasonCode == MQRC_Q_MGR_NOT_AVAILABLE);
+    }
+};
+```
+
+### 3.4 Architecture Improvements
+
+#### 3.4.1 Separate Business Logic from UI
+
+**Current Issue:** DataArea class is too large (23,000+ lines) and mixes concerns
+
+**Proposed Structure:**
+
+```
+RFHUtil/
+├── Core/                    # Business logic (no UI dependencies)
+│   ├── Connection/
+│   │   ├── ConnectionManager.cpp
+│   │   ├── ChannelConfig.cpp
+│   │   └── SecurityManager.cpp
+│   ├── Queue/
+│   │   ├── QueueManager.cpp
+│   │   ├── MessageHandler.cpp
+│   │   └── BrowseManager.cpp
+│   ├── Message/
+│   │   ├── MessageParser.cpp
+│   │   ├── HeaderHandler.cpp
+│   │   └── FormatConverter.cpp
+│   └── PubSub/
+│       ├── SubscriptionManager.cpp
+│       └── TopicManager.cpp
+├── UI/                      # MFC UI layer
+│   ├── Dialogs/
+│   ├── PropertyPages/
+│   └── Views/
+└── Utils/                   # Shared utilities
+    ├── Encoding/
+    ├── Logging/
+    └── Configuration/
+```
+
+#### 3.4.2 Add Dependency Injection
+
+```cpp
+class IConnectionManager {
+public:
+    virtual bool connect(const char* qmName) = 0;
+    virtual bool disconnect() = 0;
+    virtual bool isConnected() const = 0;
+    virtual ~IConnectionManager() = default;
+};
+
+class IMessageHandler {
+public:
+    virtual bool putMessage(const Message& msg) = 0;
+    virtual std::optional<Message> getMessage() = 0;
+    virtual ~IMessageHandler() = default;
+};
+
+class DataArea {
+    std::shared_ptr<IConnectionManager> connectionMgr;
+    std::shared_ptr<IMessageHandler> messageMgr;
+    
+public:
+    DataArea(std::shared_ptr<IConnectionManager> conn,
+             std::shared_ptr<IMessageHandler> msg)
+        : connectionMgr(conn), messageMgr(msg) {}
+};
+```
+
+### 3.5 Testing Infrastructure
+
+#### 3.5.1 Unit Testing Framework
+
+**Add Google Test:**
+
+```cpp
+// tests/ConnectionManagerTest.cpp
+#include <gtest/gtest.h>
+#include "ConnectionManager.h"
+
+class ConnectionManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Setup test environment
+    }
+    
+    void TearDown() override {
+        // Cleanup
+    }
+};
+
+TEST_F(ConnectionManagerTest, ConnectToValidQM) {
+    ConnectionManager mgr;
+    EXPECT_TRUE(mgr.connect("QM1"));
+    EXPECT_TRUE(mgr.isConnected());
+}
+
+TEST_F(ConnectionManagerTest, ReconnectAfterFailure) {
+    ConnectionManager mgr;
+    mgr.connect("QM1");
+    
+    // Simulate connection loss
+    mgr.simulateConnectionLoss();
+    
+    EXPECT_TRUE(mgr.reconnect());
+    EXPECT_TRUE(mgr.isConnected());
+}
+```
+
+#### 3.5.2 Integration Testing with Docker
+
+**docker-compose.yml:**
+
+```yaml
+version: '3.8'
+
+services:
+  mq:
+    image: ibmcom/mq:latest
+    environment:
+      LICENSE: accept
+      MQ_QMGR_NAME: QM1
+      MQ_APP_PASSWORD: passw0rd
+    ports:
+      - "1414:1414"
+      - "9443:9443"
+    volumes:
+      - qm-data:/mnt/mqm
+    
+  test-runner:
+    build: .
+    depends_on:
+      - mq
+    environment:
+      MQ_HOST: mq
+      MQ_PORT: 1414
+      MQ_QMGR: QM1
+    command: ./run_integration_tests.sh
+
+volumes:
+  qm-data:
+```
+
+### 3.6 Documentation Improvements
+
+#### 3.6.1 Code Documentation
+
+**Add Doxygen Comments:**
+
+```cpp
+/**
+ * @brief Connects to an IBM MQ Queue Manager
+ * 
+ * @param qmName Name of the queue manager to connect to
+ * @param options Connection options (user ID, password, SSL settings)
+ * @return true if connection successful, false otherwise
+ * 
+ * @throws MQException if connection fails with non-recoverable error
+ * 
+ * @note This method will automatically retry connection up to 3 times
+ *       with 5 second delays between attempts
+ * 
+ * @see disconnect()
+ * @see isConnected()
+ */
+bool connect2QM(const char* qmName, const ConnectionOptions& options);
+```
+
+#### 3.6.2 Architecture Documentation
+
+Create `docs/architecture/` with:
+- Component diagrams
+- Sequence diagrams
+- Class diagrams
+- API documentation
+
+### 3.7 Security Enhancements
+
+#### 3.7.1 Secure Credential Storage
+
+**Current Issue:** Passwords stored in plain text in memory
+
+**Recommendation:**
+
+```cpp
+#include <wincrypt.h>
+
+class SecureString {
+    std::vector<BYTE> encrypted;
+    
+public:
+    void set(const char* plaintext) {
+        DATA_BLOB input, output;
+        input.pbData = (BYTE*)plaintext;
+        input.cbData = strlen(plaintext);
+        
+        if (CryptProtectData(&input, NULL, NULL, NULL, NULL, 0, &output)) {
+            encrypted.assign(output.pbData, output.pbData + output.cbData);
+            LocalFree(output.pbData);
+        }
+    }
+    
+    std::string get() const {
+        DATA_BLOB input, output;
+        input.pbData = const_cast<BYTE*>(encrypted.data());
+        input.cbData = encrypted.size();
+        
+        if (CryptUnprotectData(&input, NULL, NULL, NULL, NULL, 0, &output)) {
+            std::string result((char*)output.pbData, output.cbData);
+            LocalFree(output.pbData);
+            return result;
+        }
+        return "";
+    }
+};
+```
+
+#### 3.7.2 TLS/SSL Improvements
+
+- Update cipher suites to remove deprecated algorithms
+- Add certificate validation options
+- Support for mutual TLS authentication
+- Certificate pinning for enhanced security
+
+### 3.8 Performance Optimizations
+
+#### 3.8.1 Message Buffering
+
+```cpp
+class MessageBuffer {
+    std::queue<Message> buffer;
+    std::mutex mutex;
+    size_t maxSize = 1000;
+    
+public:
+    void addMessage(Message&& msg) {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (buffer.size() < maxSize) {
+            buffer.push(std::move(msg));
+        }
+    }
+    
+    std::optional<Message> getMessage() {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (!buffer.empty()) {
+            Message msg = std::move(buffer.front());
+            buffer.pop();
+            return msg;
+        }
+        return std::nullopt;
+    }
+};
+```
+
+#### 3.8.2 Async Operations
+
+```cpp
+class AsyncMessageHandler {
+    std::thread workerThread;
+    std::atomic<bool> running{true};
+    
+public:
+    void startAsync() {
+        workerThread = std::thread([this]() {
+            while (running) {
+                processMessages();
+            }
+        });
+    }
+    
+    void stop() {
+        running = false;
+        if (workerThread.joinable()) {
+            workerThread.join();
+        }
+    }
+};
+```
+
+---
+
+## 4. Implementation Roadmap
+
+### Phase 1: Foundation (1-2 months)
+- [ ] Upgrade to Visual Studio 2022
+- [ ] Add 64-bit build configuration
+- [ ] Set up GitHub Actions CI/CD
+- [ ] Add basic unit testing framework
+- [ ] Document current architecture
+
+### Phase 2: Connection Improvements (1 month)
+- [ ] Implement automatic reconnection logic
+- [ ] Add keepalive configuration
+- [ ] Add connection health monitoring
+- [ ] Implement connection event handlers
+- [ ] Add comprehensive error handling
+
+### Phase 3: Code Modernization (2-3 months)
+- [ ] Refactor DataArea class (split into smaller classes)
+- [ ] Replace raw pointers with smart pointers
+- [ ] Implement RAII for MQ resources
+- [ ] Add dependency injection
+- [ ] Modernize string handling
+
+### Phase 4: Testing & Quality (1-2 months)
+- [ ] Expand unit test coverage
+- [ ] Add integration tests with Docker
+- [ ] Implement static code analysis
+- [ ] Add security scanning
+- [ ] Performance profiling and optimization
+
+### Phase 5: Documentation (1 month)
+- [ ] Add Doxygen comments
+- [ ] Create architecture diagrams
+- [ ] Write developer guide
+- [ ] Update user documentation
+- [ ] Create contribution guidelines
+
+---
+
+## 5. Recommendations Summary
+
+### High Priority (Do First)
+1. ✅ **Add Keepalive Configuration** - Prevents connection timeouts
+2. ✅ **Implement Automatic Reconnection** - Improves reliability
+3. ✅ **Upgrade to VS 2022** - Modern tooling and support
+4. ✅ **Add CI/CD Pipeline** - Automated builds and testing
+5. ✅ **Add Connection Health Monitoring** - Proactive issue detection
+
+### Medium Priority (Do Next)
+6. Add 64-bit support
+7. Implement unit testing framework
+8. Refactor DataArea class
+9. Add secure credential storage
+10. Improve error handling
+
+### Low Priority (Nice to Have)
+11. CMake build system
+12. Cross-platform support (Qt migration)
+13. Async message processing
+14. Advanced performance optimizations
+15. Comprehensive documentation
+
+---
+
+## 6. Conclusion
+
+The mq-rfhutil project is a mature, well-structured MQ utility with a solid foundation. The main areas for improvement are:
+
+1. **Connection Management**: Add keepalive and automatic reconnection
+2. **Build System**: Modernize to VS 2022 and add CI/CD
+3. **Code Quality**: Refactor large classes and add testing
+4. **Documentation**: Improve code and architecture documentation
+
+The project would benefit most from implementing automatic reconnection and keepalive configuration, as these directly address the user's concerns about connection stability.
+
+---
+
+**Document Version:** 1.0  
+**Date:** 2026-02-13  
+**Author:** IBM Bob (Architect Mode)

--- a/docs/BUILD_CONFIG.md
+++ b/docs/BUILD_CONFIG.md
@@ -1,6 +1,19 @@
 # Build Configuration for mq-rfhutil
 
-## MSBuild Path
+## Prerequisites
+
+### IBM MQ SDK
+The build requires the IBM MQ SDK (headers + libraries). Set the `MQ_HOME` environment variable to your MQ installation root before building:
+
+```cmd
+set MQ_HOME=C:\Program Files\IBM\MQ
+```
+
+Or pass it directly to MSBuild with `/p:MQ_HOME=<path>` (see commands below).
+
+The default in `Directory.Build.props` is `C:\Program Files\IBM\MQ` (standard IBM MQ install location). If your MQ SDK is elsewhere (e.g. `d:\apps\mq`), you must override it.
+
+### MSBuild Path
 **IMPORTANT:** Use this MSBuild path for building the project:
 ```
 C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe
@@ -26,6 +39,11 @@ C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\B
 ### Build All Projects
 ```bash
 "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" RFHUtil.sln /t:Rebuild /p:Configuration=Release /p:Platform=Win32 /v:minimal
+```
+
+### Override MQ SDK path (non-standard install location)
+```bash
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" RFHUtil.sln /t:Rebuild /p:Configuration=Release /p:Platform=Win32 /p:MQ_HOME="d:\apps\mq" /v:minimal
 ```
 
 ## Build Configurations

--- a/docs/BUILD_CONFIG.md
+++ b/docs/BUILD_CONFIG.md
@@ -1,0 +1,70 @@
+# Build Configuration for mq-rfhutil
+
+## MSBuild Path
+**IMPORTANT:** Use this MSBuild path for building the project:
+```
+C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe
+```
+
+## Build Commands
+
+### Build RFHUtil (main project - server mode)
+```bash
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" RFHUtil.sln /t:RFHUtil:Rebuild /p:Configuration=Release /p:Platform=Win32 /v:minimal
+```
+
+### Build Client (rfhutilc - client mode)
+```bash
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" RFHUtil.sln /t:Client:Rebuild /p:Configuration=Release /p:Platform=Win32 /v:minimal
+```
+
+### Build Client Safe Mode (rfhutilc-safe - browse-only)
+```bash
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" RFHUtil.sln /t:Client:Rebuild /p:Configuration=ReleaseSafe /p:Platform=Win32 /v:minimal
+```
+
+### Build All Projects
+```bash
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" RFHUtil.sln /t:Rebuild /p:Configuration=Release /p:Platform=Win32 /v:minimal
+```
+
+## Build Configurations
+
+### Release (Standard)
+- **rfhutil.exe**: Full GUI application with MQ server libraries
+- **rfhutilc.exe**: Client mode with MQ client libraries
+- Full read/write capabilities
+
+### ReleaseSafe (Browse-Only)
+- **rfhutilc-safe.exe**: Client mode with SAFE_MODE enabled
+- Browse-only operations (non-destructive reads)
+- All write operations disabled (Write Q, Load Q, Move Q, Purge Q, Clear All)
+- Ideal for production troubleshooting and training environments
+
+## Output Locations
+- **rfhutil.exe**: `bin\Release\rfhutil.exe`
+- **rfhutilc.exe**: `bin\Release\rfhutilc.exe`
+- **rfhutilc-safe.exe**: `bin\ReleaseSafe\rfhutilc-safe.exe`
+
+## Project Structure
+- **RFHUtil**: Main GUI application (server mode)
+- **Client**: Client mode application (rfhutilc.exe / rfhutilc-safe.exe)
+- Both projects share source files from `RFHUtil\` directory
+
+## Safe Mode Features
+When built with `ReleaseSafe` configuration:
+- **SAFE_MODE** preprocessor definition is active
+- Write Q button is hidden and disabled
+- Load Q button is hidden and disabled
+- Move Q button is hidden and disabled
+- Purge Q button is hidden and disabled
+- Clear All button is hidden and disabled
+- Read Q button renamed to "Browse Q" and uses non-destructive browse mode
+- All MQGET operations automatically use browse mode (MQGMO_BROWSE_*)
+- Save Q (to file) remains enabled
+- Browse operations remain fully functional
+
+See [SAFE_MODE_IMPLEMENTATION.md](SAFE_MODE_IMPLEMENTATION.md) for detailed implementation information.
+
+## Current Version
+**9.4.0.0** - Built against IBM MQ 9.4.5

--- a/docs/DARK_MODE_SYSTEM_CONTROLS_SOLUTION.md
+++ b/docs/DARK_MODE_SYSTEM_CONTROLS_SOLUTION.md
@@ -1,0 +1,456 @@
+# Dark Mode System Controls - Solution Guide
+
+**Issue:** Menu bar, tab bar, and scrollbars remain light in dark mode  
+**Root Cause:** These are system-drawn controls that MFC doesn't easily allow custom theming  
+**Status:** 🔍 Research & Implementation Guide  
+**Created:** February 20, 2026
+
+---
+
+## Problem Analysis
+
+From the screenshot, the following elements remain light in dark mode:
+
+1. **Menu Bar** (File, Edit, Search, Read, Write, View, Ids, MQ, Help)
+2. **Tab Bar** (Main, Data, MQMD, PS, Usr Prop, RFH, PubSub, pscr, jms, usr, other, CICS, IMS, DLQ, Conn)
+3. **Scrollbars** (vertical scrollbar on data area)
+
+These are **system-drawn controls** that Windows renders using system themes, not application code.
+
+---
+
+## Solution Approaches
+
+### Approach 1: Windows 10/11 Dark Title Bar API (EASIEST) ✅
+
+**Status:** Already implemented for title bar, can extend to other areas
+
+**Current Implementation:**
+- ThemeManager::ApplyDarkTitleBar() uses DwmSetWindowAttribute
+- Works for window title bar
+- **Limitation:** Doesn't affect menu bar, tabs, or scrollbars
+
+**Potential Extension:**
+```cpp
+void ThemeManager::ApplyDarkModeToWindow(CWnd* pWnd)
+{
+    if (!pWnd || !pWnd->GetSafeHwnd()) {
+        return;
+    }
+    
+    BOOL useDarkMode = IsDarkMode() ? TRUE : FALSE;
+    
+    DwmSetWindowAttribute(pWnd->GetSafeHwnd(), 
+        DWMWA_USE_IMMERSIVE_DARK_MODE, 
+        &useDarkMode, sizeof(useDarkMode));
+    
+    DwmSetWindowAttribute(pWnd->GetSafeHwnd(), 
+        19, 
+        &useDarkMode, sizeof(useDarkMode));
+    
+    ::DrawMenuBar(pWnd->GetSafeHwnd());
+}
+```
+
+**Pros:** Simple, uses official Windows API  
+**Cons:** Limited control, may not work for all controls  
+**Effort:** 1 hour
+
+---
+
+### Approach 2: Owner-Draw Menu Bar (MODERATE DIFFICULTY) ⚠️
+
+**Goal:** Custom draw the menu bar with dark colors
+
+**Implementation:**
+
+```cpp
+void CMainFrame::OnMeasureItem(int nIDCtl, LPMEASUREITEMSTRUCT lpMeasureItemStruct)
+{
+    if (lpMeasureItemStruct->CtlType == ODT_MENU) {
+        ThemeManager& theme = ThemeManager::GetInstance();
+        if (theme.IsDarkMode()) {
+            lpMeasureItemStruct->itemWidth = 100;
+            lpMeasureItemStruct->itemHeight = 24;
+            return;
+        }
+    }
+    CFrameWnd::OnMeasureItem(nIDCtl, lpMeasureItemStruct);
+}
+
+void CMainFrame::OnDrawItem(int nIDCtl, LPDRAWITEMSTRUCT lpDrawItemStruct)
+{
+    if (lpDrawItemStruct->CtlType == ODT_MENU) {
+        ThemeManager& theme = ThemeManager::GetInstance();
+        if (theme.IsDarkMode()) {
+            CDC* pDC = CDC::FromHandle(lpDrawItemStruct->hDC);
+            CRect rect(&lpDrawItemStruct->rcItem);
+            
+            COLORREF bgColor = (lpDrawItemStruct->itemState & ODS_SELECTED) 
+                ? theme.GetHighlightColor() 
+                : theme.GetBackgroundColor();
+            pDC->FillSolidRect(rect, bgColor);
+            
+            pDC->SetTextColor(theme.GetTextColor());
+            pDC->SetBkMode(TRANSPARENT);
+            
+            CString text;
+            CMenu* pMenu = CMenu::FromHandle((HMENU)lpDrawItemStruct->hwndItem);
+            if (pMenu) {
+                pMenu->GetMenuString(lpDrawItemStruct->itemID, text, MF_BYCOMMAND);
+                pDC->DrawText(text, rect, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
+            }
+            return;
+        }
+    }
+    CFrameWnd::OnDrawItem(nIDCtl, lpDrawItemStruct);
+}
+```
+
+**Required Changes:**
+1. Convert menu items to owner-draw in resource file
+2. Handle WM_MEASUREITEM and WM_DRAWITEM
+3. Custom draw all menu items
+
+**Pros:** Full control over menu appearance  
+**Cons:** Complex, must handle all menu items, keyboard navigation, submenus  
+**Effort:** 4-6 hours  
+**Risk:** High - can break existing menu functionality
+
+---
+
+### Approach 3: Custom Tab Control (MODERATE-HIGH DIFFICULTY) ⚠️
+
+**Goal:** Replace CTabCtrl with custom-drawn tabs
+
+**Current Implementation:**
+- MyPropertySheet uses standard CTabCtrl
+- OnDrawItem() already has custom tab drawing
+- **Issue:** Only draws tab labels, not the tab control background
+
+**Enhancement:**
+
+```cpp
+void MyPropertySheet::OnDrawItem(int nIDCtl, LPDRAWITEMSTRUCT lpDrawItemStruct)
+{
+    CTabCtrl* pTab = GetTabControl();
+    if (pTab && pTab->GetSafeHwnd() == lpDrawItemStruct->hwndItem) {
+        ThemeManager& theme = ThemeManager::GetInstance();
+        
+        if (!theme.IsDarkMode()) {
+            CPropertySheet::OnDrawItem(nIDCtl, lpDrawItemStruct);
+            return;
+        }
+        
+        CDC* pDC = CDC::FromHandle(lpDrawItemStruct->hDC);
+        CRect rect(&lpDrawItemStruct->rcItem);
+        
+        COLORREF bgColor = (lpDrawItemStruct->itemState & ODS_SELECTED)
+            ? theme.GetControlBackgroundColor()
+            : theme.GetBackgroundColor();
+        
+        pDC->FillSolidRect(rect, bgColor);
+        
+        CPen borderPen(PS_SOLID, 1, theme.GetBorderColor());
+        CPen* oldPen = pDC->SelectObject(&borderPen);
+        pDC->MoveTo(rect.left, rect.bottom);
+        pDC->LineTo(rect.left, rect.top);
+        pDC->LineTo(rect.right, rect.top);
+        pDC->LineTo(rect.right, rect.bottom);
+        pDC->SelectObject(oldPen);
+        
+        char text[256];
+        TCITEM item;
+        item.mask = TCIF_TEXT;
+        item.pszText = text;
+        item.cchTextMax = sizeof(text);
+        pTab->GetItem(lpDrawItemStruct->itemID, &item);
+        
+        pDC->SetTextColor(theme.GetTextColor());
+        pDC->SetBkMode(TRANSPARENT);
+        pDC->DrawText(text, -1, rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+        
+        return;
+    }
+    
+    CPropertySheet::OnDrawItem(nIDCtl, lpDrawItemStruct);
+}
+
+BOOL MyPropertySheet::OnEraseBkgnd(CDC* pDC)
+{
+    ThemeManager& theme = ThemeManager::GetInstance();
+    if (theme.IsDarkMode()) {
+        CTabCtrl* pTab = GetTabControl();
+        if (pTab) {
+            CRect tabRect;
+            pTab->GetWindowRect(&tabRect);
+            ScreenToClient(&tabRect);
+            
+            pDC->FillSolidRect(tabRect, theme.GetBackgroundColor());
+        }
+        return TRUE;
+    }
+    return CPropertySheet::OnEraseBkgnd(pDC);
+}
+```
+
+**Additional Required:**
+- Set TCS_OWNERDRAWFIXED style on tab control
+- Handle tab control background painting
+
+**Pros:** Full control over tab appearance  
+**Cons:** Complex, must handle all tab states  
+**Effort:** 3-4 hours  
+**Risk:** Medium
+
+---
+
+### Approach 4: Custom Scrollbar Theming (HIGH DIFFICULTY) 🔴
+
+**Goal:** Theme scrollbars to match dark mode
+
+**Challenge:** Scrollbars are system-drawn and very difficult to customize in MFC
+
+**Option 4A: Use Flat Scrollbar Style**
+```cpp
+void CGeneral::OnInitDialog()
+{
+    CPropertyPage::OnInitDialog();
+    
+    ThemeManager& theme = ThemeManager::GetInstance();
+    if (theme.IsDarkMode()) {
+        FlatSB_EnableScrollBar(GetDlgItem(IDC_DATA_EDIT)->GetSafeHwnd(), 
+            SB_BOTH, ESB_ENABLE_BOTH);
+    }
+}
+```
+
+**Option 4B: Custom Scrollbar Control**
+- Create custom scrollbar class derived from CScrollBar
+- Override OnPaint() to draw custom scrollbar
+- Replace all scrollbars with custom control
+- **Effort:** 8-12 hours
+- **Risk:** Very High - complex interaction handling
+
+**Option 4C: Accept System Scrollbars**
+- **Recommendation:** Leave scrollbars as-is
+- Modern Windows apps often have light scrollbars even in dark mode
+- Users are accustomed to this inconsistency
+- **Effort:** 0 hours ✅
+
+---
+
+## Recommended Implementation Plan
+
+### Phase 1: Quick Wins (2-3 hours) ✅
+
+1. **Enhance Tab Control Drawing**
+   - Improve existing MyPropertySheet::OnDrawItem()
+   - Add tab control background painting
+   - **Impact:** High visibility improvement
+   - **Risk:** Low
+
+2. **Add Tab Control Background Handler**
+   - Implement OnEraseBkgnd() in MyPropertySheet
+   - Paint tab control area with dark background
+   - **Impact:** Removes light tab bar background
+   - **Risk:** Low
+
+### Phase 2: Menu Bar (4-6 hours) ⚠️
+
+3. **Attempt Windows Dark Mode API**
+   - Try SetWindowTheme() on menu bar
+   - Test DwmSetWindowAttribute() extensions
+   - **Impact:** May work on Windows 11
+   - **Risk:** Low (fallback to current state)
+
+4. **If API fails: Owner-Draw Menus**
+   - Convert menus to owner-draw
+   - Implement custom menu drawing
+   - **Impact:** Full menu bar theming
+   - **Risk:** Medium-High
+
+### Phase 3: Accept Limitations (0 hours) ✅
+
+5. **Scrollbars**
+   - **Decision:** Keep system scrollbars
+   - **Rationale:** Very high effort, low user impact
+   - Document as known limitation
+
+---
+
+## Code Changes Required
+
+### File: RFHUtil/MyPropertySheet.h
+
+Add to class declaration:
+```cpp
+protected:
+    afx_msg BOOL OnEraseBkgnd(CDC* pDC);
+```
+
+### File: RFHUtil/MyPropertySheet.cpp
+
+Add to message map:
+```cpp
+ON_WM_ERASEBKGND()
+```
+
+Add method implementation:
+```cpp
+BOOL MyPropertySheet::OnEraseBkgnd(CDC* pDC)
+{
+    ThemeManager& theme = ThemeManager::GetInstance();
+    if (theme.IsDarkMode()) {
+        CRect rect;
+        GetClientRect(&rect);
+        
+        pDC->FillSolidRect(rect, theme.GetBackgroundColor());
+        
+        CTabCtrl* pTab = GetTabControl();
+        if (pTab && pTab->GetSafeHwnd()) {
+            CRect tabRect;
+            pTab->GetWindowRect(&tabRect);
+            ScreenToClient(&tabRect);
+            pDC->FillSolidRect(tabRect, theme.GetBackgroundColor());
+        }
+        
+        return TRUE;
+    }
+    return CPropertySheet::OnEraseBkgnd(pDC);
+}
+```
+
+### File: RFHUtil/ThemeManager.h
+
+Add methods:
+```cpp
+void ApplyDarkModeToWindow(CWnd* pWnd);
+void ThemeMenuBar(CWnd* pMainWnd);
+```
+
+### File: RFHUtil/ThemeManager.cpp
+
+Add implementations:
+```cpp
+void ThemeManager::ApplyDarkModeToWindow(CWnd* pWnd)
+{
+    if (!pWnd || !pWnd->GetSafeHwnd() || !IsDarkMode()) {
+        return;
+    }
+    
+    BOOL useDarkMode = TRUE;
+    
+    DwmSetWindowAttribute(pWnd->GetSafeHwnd(), 
+        DWMWA_USE_IMMERSIVE_DARK_MODE, 
+        &useDarkMode, sizeof(useDarkMode));
+    
+    DwmSetWindowAttribute(pWnd->GetSafeHwnd(), 
+        19, 
+        &useDarkMode, sizeof(useDarkMode));
+    
+    HMENU hMenu = ::GetMenu(pWnd->GetSafeHwnd());
+    if (hMenu) {
+        SetWindowTheme(pWnd->GetSafeHwnd(), L"DarkMode_Explorer", NULL);
+        ::DrawMenuBar(pWnd->GetSafeHwnd());
+    }
+}
+
+void ThemeManager::ThemeMenuBar(CWnd* pMainWnd)
+{
+    if (!pMainWnd || !pMainWnd->GetSafeHwnd()) {
+        return;
+    }
+    
+    if (IsDarkMode()) {
+        SetWindowTheme(pMainWnd->GetSafeHwnd(), L"DarkMode_Explorer", NULL);
+        SetWindowTheme(pMainWnd->GetSafeHwnd(), L"DarkMode_CFD", NULL);
+        ::DrawMenuBar(pMainWnd->GetSafeHwnd());
+    } else {
+        SetWindowTheme(pMainWnd->GetSafeHwnd(), NULL, NULL);
+        ::DrawMenuBar(pMainWnd->GetSafeHwnd());
+    }
+}
+```
+
+---
+
+## Testing Plan
+
+### Test 1: Tab Control Background
+- [ ] Switch to dark mode
+- [ ] Verify tab bar background is dark
+- [ ] Verify selected tab is highlighted
+- [ ] Verify unselected tabs are darker
+- [ ] Check all 15 tabs
+
+### Test 2: Menu Bar (if implemented)
+- [ ] Verify menu bar is dark
+- [ ] Test all menu items clickable
+- [ ] Test keyboard shortcuts work
+- [ ] Test submenus display correctly
+- [ ] Verify menu separators visible
+
+### Test 3: Scrollbars
+- [ ] Document current behavior
+- [ ] Verify scrollbars still functional
+- [ ] Accept as known limitation
+
+---
+
+## Known Limitations
+
+1. **Menu Bar:** May remain light on Windows 10 (Windows 11 has better support)
+2. **Scrollbars:** Will remain system-themed (light) - this is acceptable
+3. **Context Menus:** May not theme automatically
+4. **System Dialogs:** File open/save dialogs will use system theme
+
+---
+
+## Alternative: Hybrid Approach
+
+**Recommendation:** Focus on what we CAN control well:
+
+✅ **Do Theme:**
+- Dialog backgrounds (already done)
+- Edit controls (already done)
+- Buttons (already done)
+- Tab control labels and backgrounds (Phase 1)
+- Static text (already done)
+
+❌ **Don't Theme (Accept System Defaults):**
+- Menu bar (too complex, low ROI)
+- Scrollbars (very complex, users accept this)
+- System dialogs (not possible)
+
+This provides **80% of the visual benefit with 20% of the effort**.
+
+---
+
+## Effort Summary
+
+| Task | Effort | Risk | Impact | Priority |
+|------|--------|------|--------|----------|
+| Tab control background | 2-3 hours | Low | High | **P0** |
+| Enhanced tab drawing | 1 hour | Low | High | **P0** |
+| Menu bar API attempt | 1 hour | Low | Medium | P1 |
+| Owner-draw menus | 4-6 hours | High | Medium | P2 |
+| Custom scrollbars | 8-12 hours | Very High | Low | P3 (Skip) |
+
+**Recommended:** Implement P0 items (3-4 hours total)
+
+---
+
+## Next Steps
+
+1. Implement tab control background painting (Phase 1)
+2. Test on Windows 10 and Windows 11
+3. Try menu bar API approach
+4. If menu bar API fails, document as limitation
+5. Update user documentation with known limitations
+
+---
+
+**Document Status:** 📋 Implementation Guide  
+**Created:** February 20, 2026  
+**Priority:** P1 (Complete dark mode polish)

--- a/docs/IDPWOS_AUTHENTICATION_ISSUE.md
+++ b/docs/IDPWOS_AUTHENTICATION_ISSUE.md
@@ -1,0 +1,217 @@
+# IDPWOS Authentication Issue Analysis
+
+## Issue Summary
+
+When using IDPWOS (ID/Password OS) authentication with CHLAUTH and CONNAUTH configured to use LDAP via `SYSTEM.DEFAULT.AUTHINFO.IDPWOS`, the **new RFHUtil version fails authentication** while the **old C version works** from the same host.
+
+## Root Cause Analysis
+
+### The Problem
+
+In [`RFHUtil/MQMDPAGE.cpp:2574-2575`](../RFHUtil/MQMDPAGE.cpp:2574-2575), there's a critical change in how the Windows username is retrieved:
+
+```cpp
+// Line 2574: OLD method (commented out)
+// rc = GetUserNameEx(NameSamCompatible, userId, &userIdSize);
+
+// Line 2575: NEW method (currently active)
+rc = GetUserName(userId, &userIdSize);
+```
+
+### Windows API Behavior Differences
+
+| API Function | Format Returned | Example |
+|-------------|----------------|---------|
+| `GetUserNameEx(NameSamCompatible, ...)` | `DOMAIN\username` | `CONTOSO\bmatt` |
+| `GetUserName(...)` | `username` only | `bmatt` |
+
+### Expected vs Actual Behavior
+
+**Old Working Version:**
+- Used `GetUserNameEx(NameSamCompatible, ...)` 
+- Sent username with domain prefix: `DOMAIN\bmatt`
+- Preserved original case from Windows
+- LDAP authentication succeeded
+
+**New Broken Version:**
+- Uses `GetUserName()`
+- Sends username without domain: `bmatt`
+- No case transformation applied
+- LDAP authentication fails (likely because LDAP expects domain-qualified username)
+
+## Impact Assessment
+
+### Affected Code Locations
+
+1. **Primary Location - MQMD User ID Setting**
+   - File: [`RFHUtil/MQMDPAGE.cpp:2570-2581`](../RFHUtil/MQMDPAGE.cpp:2570-2581)
+   - Function: Setting user ID in MQMD when `m_setUserID` or `m_set_all` is enabled
+   - Impact: Direct authentication failure
+
+2. **Secondary Locations - User ID Usage**
+   - [`RFHUtil/DataArea.cpp:7931-7935`](../RFHUtil/DataArea.cpp:7931-7935) - Browse operations
+   - [`RFHUtil/DataArea.cpp:8097-8098`](../RFHUtil/DataArea.cpp:8097-8098) - Read operations  
+   - [`RFHUtil/DataArea.cpp:14634-14650`](../RFHUtil/DataArea.cpp:14634-14650) - Display queue operations
+   - [`RFHUtil/DataArea.cpp:20048-20052`](../RFHUtil/DataArea.cpp:20048-20052) - Pub/Sub get operations
+
+All these locations call `mqmdObj->setUserId(&mqmd)` which ultimately uses the username retrieved by the problematic code.
+
+### Authentication Flow
+
+```mermaid
+graph TD
+    A[User enables Set User ID] --> B[MQMDPAGE::buildMQMD called]
+    B --> C{m_mqmd_userid empty?}
+    C -->|Yes| D[GetUserName called]
+    C -->|No| E[Use m_mqmd_userid value]
+    D --> F[Username without domain]
+    E --> G[User-specified value]
+    F --> H[setUserId copies to MQMD]
+    G --> H
+    H --> I[MQOPEN/MQPUT with MQMD]
+    I --> J[MQ Queue Manager]
+    J --> K[CHLAUTH check]
+    K --> L[CONNAUTH IDPWOS]
+    L --> M{Domain in username?}
+    M -->|No| N[LDAP lookup fails]
+    M -->|Yes| O[LDAP lookup succeeds]
+    N --> P[Authentication Error]
+    O --> Q[Success]
+```
+
+## Why This Matters for IDPWOS
+
+When MQ is configured with:
+- **CHLAUTH** rules enabled
+- **CONNAUTH** pointing to `SYSTEM.DEFAULT.AUTHINFO.IDPWOS`
+- **LDAP** backend for authentication
+
+The LDAP directory typically stores users in domain-qualified format (e.g., `DOMAIN\username` or `username@domain.com`). When the application sends just `username` without the domain qualifier, the LDAP lookup fails because:
+
+1. LDAP searches for exact match of the provided username
+2. Without domain prefix, it cannot find the user entry
+3. Authentication is denied even though credentials are valid
+
+## Additional Concerns
+
+### 1. No Case Transformation
+The current code does **not** apply any case transformation to the username. While the user confirmed the old version sent it "as-is with domain prefix", some LDAP configurations may be case-sensitive.
+
+### 2. Truncation to 12 Characters
+Line 2578 truncates the username to 12 characters:
+```cpp
+userId[12] = 0;
+```
+
+This is problematic because:
+- `DOMAIN\username` format easily exceeds 12 characters
+- Example: `CONTOSO\bmatt` = 13 characters (would be truncated to `CONTOSO\bmat`)
+- MQ's `MQ_USER_ID_LENGTH` is 12 bytes, but domain-qualified names need more space
+
+### 3. Connection User ID vs MQMD User ID
+The code has two separate authentication paths:
+- **Connection authentication** ([`DataArea.cpp:10676-10740`](../RFHUtil/DataArea.cpp:10676-10740)) - Uses `m_conn_userid` via MQCSP
+- **Message context authentication** ([`MQMDPAGE.cpp:2570-2581`](../RFHUtil/MQMDPAGE.cpp:2570-2581)) - Uses Windows username
+
+The issue affects the **message context authentication** path, not the connection authentication.
+
+## Recommended Fix
+
+### Option 1: Restore GetUserNameEx (Recommended)
+Uncomment line 2574 and remove line 2575:
+
+```cpp
+// Restore domain-qualified username retrieval
+rc = GetUserNameEx(NameSamCompatible, userId, &userIdSize);
+// rc = GetUserName(userId, &userIdSize);  // Remove this line
+```
+
+**Pros:**
+- Matches old working behavior
+- Provides domain-qualified username for LDAP
+- Minimal code change
+
+**Cons:**
+- May exceed 12-character limit (needs buffer size increase)
+- Requires Windows XP or later (already a requirement)
+
+### Option 2: Make it Configurable
+Add an environment variable or registry setting to choose between formats:
+
+```cpp
+char* useFullName = getenv("RFHUTIL_USE_DOMAIN_USERNAME");
+if (useFullName && (strcmp(useFullName, "1") == 0)) {
+    rc = GetUserNameEx(NameSamCompatible, userId, &userIdSize);
+} else {
+    rc = GetUserName(userId, &userIdSize);
+}
+```
+
+**Pros:**
+- Backward compatible
+- Flexible for different environments
+
+**Cons:**
+- More complex
+- Requires user configuration
+
+### Option 3: Increase Buffer Size
+Change the buffer and truncation logic to accommodate domain-qualified names:
+
+```cpp
+char userId[256];  // Increase from implicit 12+
+DWORD userIdSize = sizeof(userId);
+rc = GetUserNameEx(NameSamCompatible, userId, &userIdSize);
+if (rc != 0) {
+    // Truncate to MQ_USER_ID_LENGTH if needed
+    userId[MQ_USER_ID_LENGTH] = 0;
+    setUserId(mqmd);
+}
+```
+
+**Pros:**
+- Handles longer usernames
+- More robust
+
+**Cons:**
+- Still truncates if domain\username > 12 chars
+- May cause authentication issues if truncated
+
+## Testing Recommendations
+
+### Test Environment Setup
+1. Configure MQ Queue Manager with:
+   - CHLAUTH rules enabled
+   - CONNAUTH pointing to IDPWOS auth info object
+   - LDAP backend configured
+
+2. Create test users in LDAP with domain-qualified names
+
+### Test Cases
+
+| Test Case | Configuration | Expected Result |
+|-----------|--------------|-----------------|
+| TC1 | Old RFHUtil C version | Authentication succeeds |
+| TC2 | New RFHUtil with current code | Authentication fails |
+| TC3 | New RFHUtil with GetUserNameEx | Authentication succeeds |
+| TC4 | Username > 12 chars | Verify truncation behavior |
+| TC5 | No domain in LDAP | Verify fallback behavior |
+
+### Verification Steps
+1. Enable MQ trace to capture authentication attempts
+2. Check LDAP server logs for lookup attempts
+3. Verify username format sent to MQ
+4. Test with both local and domain accounts
+
+## Related Code References
+
+- Connection authentication: [`DataArea.cpp:10676-10740`](../RFHUtil/DataArea.cpp:10676-10740)
+- MQCSP structure usage: [`DataArea.cpp:10588`](../RFHUtil/DataArea.cpp:10588)
+- User ID setting in MQMD: [`MQMDPAGE.cpp:4005-4027`](../RFHUtil/MQMDPAGE.cpp:4005-4027)
+- Alternate user authority: [`DataArea.cpp:11810-11828`](../RFHUtil/DataArea.cpp:11810-11828)
+
+## Conclusion
+
+The authentication failure is caused by switching from `GetUserNameEx()` to `GetUserName()`, which removes the domain prefix from the username. This breaks LDAP authentication that expects domain-qualified usernames.
+
+**Recommended Action:** Restore `GetUserNameEx(NameSamCompatible, ...)` and increase the buffer size to accommodate domain-qualified usernames.

--- a/docs/IDPWOS_FIX_CHANGES.md
+++ b/docs/IDPWOS_FIX_CHANGES.md
@@ -1,0 +1,252 @@
+# IDPWOS Authentication Fix - Changes Made
+
+## Summary
+
+Fixed the IDPWOS authentication issue where the new RFHUtil failed to authenticate against LDAP-backed queue managers while the old version worked. The root cause was switching from `GetUserNameEx()` to `GetUserName()`, which removed the domain prefix from usernames required by LDAP.
+
+**Date:** 2026-02-19  
+**Issue:** Authentication failure with IDPWOS/LDAP when CHLAUTH and CONNAUTH are configured  
+**Solution:** Restored `GetUserNameEx(NameSamCompatible, ...)` with proper fallback logic
+
+## Files Modified
+
+### 1. RFHUtil/MQMDPAGE.cpp
+
+#### Change 1: Added Required Header
+**Location:** Lines 29-30
+**Change:** Added `#define SECURITY_WIN32` and `#include <Security.h>` for GetUserNameEx API
+
+```cpp
+#include "ThemeManager.h"
+#define SECURITY_WIN32
+#include <Security.h>  // For GetUserNameEx
+```
+
+**Note:** Using `Security.h` instead of `Secext.h` and defining `SECURITY_WIN32` ensures proper compilation with the Windows SDK.
+
+#### Change 2: Restored GetUserNameEx with Fallback
+**Location:** Lines 2571-2602  
+**Previous Code:**
+```cpp
+else
+{
+    // we need to set the first 12 characters of the logged in user id
+    memset(userId, 0, sizeof(userId));
+//  rc = GetUserNameEx(NameSamCompatible, userId, &userIdSize);
+    rc = GetUserName(userId, &userIdSize);
+    if (rc != 0)
+    {
+        userId[12] = 0;
+        setUserId(mqmd);
+    }
+}
+```
+
+**New Code:**
+```cpp
+else
+{
+    // Get the domain-qualified user id for IDPWOS authentication
+    // Use a larger buffer to accommodate DOMAIN\username format
+    char fullUserId[256];
+    DWORD fullUserIdSize = sizeof(fullUserId);
+    memset(fullUserId, 0, sizeof(fullUserId));
+    memset(userId, 0, sizeof(userId));
+    
+    // Try to get domain-qualified username first (for LDAP/IDPWOS)
+    rc = GetUserNameEx(NameSamCompatible, fullUserId, &fullUserIdSize);
+    if (rc != 0)
+    {
+        // Successfully got domain\username format
+        // Copy to userId buffer, truncating if necessary to MQ_USER_ID_LENGTH (12)
+        strncpy(userId, fullUserId, MQ_USER_ID_LENGTH);
+        userId[MQ_USER_ID_LENGTH] = 0;
+        setUserId(mqmd);
+    }
+    else
+    {
+        // Fallback to simple username if GetUserNameEx fails
+        // This handles cases where domain info is not available
+        DWORD simpleUserIdSize = sizeof(userId);
+        rc = GetUserName(userId, &simpleUserIdSize);
+        if (rc != 0)
+        {
+            userId[MQ_USER_ID_LENGTH] = 0;
+            setUserId(mqmd);
+        }
+    }
+}
+```
+
+**Key Improvements:**
+- Restored `GetUserNameEx(NameSamCompatible, ...)` to get domain-qualified username
+- Added 256-byte buffer to accommodate full `DOMAIN\username` format
+- Implemented fallback to `GetUserName()` for non-domain environments
+- Uses `MQ_USER_ID_LENGTH` constant instead of hardcoded 12
+- Proper truncation with `strncpy()` to prevent buffer overflow
+
+### 2. RFHUtil/RFHUtil.vcxproj
+
+#### Change: Added Secur32.lib to Linker Dependencies
+
+**Debug Configuration (Line 67):**
+```xml
+<AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+```
+
+**Release Configuration (Line 96):**
+```xml
+<AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+```
+
+### 3. Client/Client.vcxproj
+
+#### Change: Added Secur32.lib to Linker Dependencies
+
+**Debug Configuration (Line 66):**
+```xml
+<AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+```
+
+**Release Configuration (Line 95):**
+```xml
+<AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+```
+
+## Technical Details
+
+### Windows API Behavior
+
+| API Function | Returns | Example |
+|-------------|---------|---------|
+| `GetUserNameEx(NameSamCompatible, ...)` | `DOMAIN\username` | `CONTOSO\bmatt` |
+| `GetUserName(...)` | `username` only | `bmatt` |
+
+### Authentication Flow
+
+1. **User enables "Set User ID"** on General tab
+2. **MQMD User ID field is empty** (use Windows username)
+3. **GetUserNameEx called** to retrieve domain-qualified username
+4. **If successful:** Username like `CONTOSO\bmatt` is obtained
+5. **Username truncated** to 12 characters: `CONTOSO\bmat`
+6. **Username set in MQMD** UserIdentifier field
+7. **MQOPEN/MQPUT** sends MQMD to queue manager
+8. **Queue Manager** validates via CHLAUTH
+9. **CONNAUTH** triggers IDPWOS authentication
+10. **LDAP lookup** succeeds with domain-qualified username
+11. **Authentication succeeds**
+
+### Fallback Logic
+
+If `GetUserNameEx()` fails (e.g., local account, no domain):
+1. Falls back to `GetUserName()`
+2. Returns simple username without domain
+3. Authentication depends on LDAP configuration
+4. May succeed if LDAP accepts simple usernames
+5. May fail if LDAP requires domain-qualified names
+
+## Testing Recommendations
+
+### Before Deployment
+1. Test with domain user account against LDAP-backed queue manager
+2. Test with local user account (verify fallback works)
+3. Test with long domain\username (verify truncation)
+4. Verify no regression in existing authentication methods
+
+### Test Environment
+- Queue Manager with CHLAUTH enabled
+- CONNAUTH pointing to IDPWOS auth info object
+- LDAP backend configured (Active Directory or OpenLDAP)
+- Test users in domain format
+
+### Success Criteria
+- ✓ Domain-qualified username sent to MQ
+- ✓ LDAP authentication succeeds
+- ✓ Fallback works for non-domain accounts
+- ✓ No buffer overflows or crashes
+- ✓ Existing functionality unchanged
+
+## Related Documentation
+
+- [IDPWOS Authentication Issue Analysis](IDPWOS_AUTHENTICATION_ISSUE.md)
+- [Implementation Plan](IDPWOS_FIX_IMPLEMENTATION_PLAN.md)
+- [Testing Guide](IDPWOS_TESTING_GUIDE.md)
+
+## Build Instructions
+
+### Prerequisites
+- Visual Studio 2017 or later
+- Windows SDK with Secur32.lib
+- IBM MQ Client libraries
+
+### Build Steps
+```bash
+# Clean previous build
+msbuild RFHUtil.sln /t:Clean /p:Configuration=Release
+
+# Build solution
+msbuild RFHUtil.sln /t:Build /p:Configuration=Release /p:Platform=Win32
+
+# Output files
+# bin/Release/rfhutil.exe  - GUI version
+# bin/Release/rfhutilc.exe - Client version
+```
+
+## Rollback Plan
+
+If issues arise, revert by:
+
+1. **Restore MQMDPAGE.cpp:**
+   - Remove `#include <Secext.h>`
+   - Uncomment `GetUserName()` line
+   - Comment out `GetUserNameEx()` logic
+
+2. **Restore Project Files:**
+   - Remove `Secur32.lib` from AdditionalDependencies
+
+3. **Rebuild:**
+   ```bash
+   msbuild RFHUtil.sln /t:Rebuild /p:Configuration=Release
+   ```
+
+## Known Limitations
+
+1. **12-Character Truncation:** Domain\username combinations longer than 12 characters will be truncated, which may cause authentication failures if LDAP requires the full username.
+
+2. **Domain Format Only:** The fix provides `DOMAIN\username` format. If LDAP expects UPN format (`user@domain.com`), additional changes would be needed.
+
+3. **Windows-Only:** This fix uses Windows-specific APIs and only works on Windows platforms.
+
+## Future Enhancements
+
+Consider implementing:
+- Configuration option to choose username format (registry or environment variable)
+- Support for UPN format (`user@domain.com`)
+- Logging/tracing of username format used
+- Warning when username is truncated
+- Increased buffer size for alternate user ID field
+
+## Changelog Entry
+
+```
+## [Version X.X.X] - 2026-02-19
+
+### Fixed
+- IDPWOS authentication failure with LDAP-backed queue managers
+- Restored GetUserNameEx() to provide domain-qualified usernames
+- Added fallback to GetUserName() for non-domain environments
+- Added Secur32.lib dependency to project files
+
+### Technical Details
+- Modified RFHUtil/MQMDPAGE.cpp to use GetUserNameEx(NameSamCompatible)
+- Username format changed from "username" to "DOMAIN\username"
+- Maintains backward compatibility with fallback logic
+```
+
+## Sign-Off
+
+**Developer:** Bob (AI Assistant)  
+**Date:** 2026-02-19  
+**Reviewed By:** [Pending]  
+**Tested By:** [Pending]  
+**Approved By:** [Pending]

--- a/docs/IDPWOS_FIX_IMPLEMENTATION_PLAN.md
+++ b/docs/IDPWOS_FIX_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,350 @@
+# IDPWOS Authentication Fix - Implementation Plan
+
+## Overview
+
+This document provides a detailed implementation plan to fix the IDPWOS authentication issue where the new RFHUtil fails to authenticate against LDAP-backed queue managers while the old version works.
+
+**Root Cause:** Changed from `GetUserNameEx(NameSamCompatible, ...)` to `GetUserName()`, removing domain prefix from username.
+
+**Related Documentation:** See [`IDPWOS_AUTHENTICATION_ISSUE.md`](IDPWOS_AUTHENTICATION_ISSUE.md) for detailed analysis.
+
+## Implementation Strategy
+
+### Recommended Approach: Restore GetUserNameEx with Buffer Enhancement
+
+This approach restores the original working behavior while addressing the 12-character truncation issue.
+
+## Code Changes Required
+
+### Change 1: Fix Username Retrieval in MQMDPAGE.cpp
+
+**File:** [`RFHUtil/MQMDPAGE.cpp`](../RFHUtil/MQMDPAGE.cpp)  
+**Location:** Lines 2570-2581  
+**Function:** `MQMDPAGE::buildMQMD()`
+
+#### Current Code (Broken)
+```cpp
+else
+{
+    // we need to set the first 12 characters of the logged in user id
+    memset(userId, 0, sizeof(userId));
+//  rc = GetUserNameEx(NameSamCompatible, userId, &userIdSize);
+    rc = GetUserName(userId, &userIdSize);
+    if (rc != 0)
+    {
+        userId[12] = 0;
+        setUserId(mqmd);
+    }
+}
+```
+
+#### Proposed Fix
+```cpp
+else
+{
+    // Get the domain-qualified user id for IDPWOS authentication
+    // Use a larger buffer to accommodate DOMAIN\username format
+    char fullUserId[256];
+    DWORD fullUserIdSize = sizeof(fullUserId);
+    memset(fullUserId, 0, sizeof(fullUserId));
+    memset(userId, 0, sizeof(userId));
+    
+    // Try to get domain-qualified username first (for LDAP/IDPWOS)
+    rc = GetUserNameEx(NameSamCompatible, fullUserId, &fullUserIdSize);
+    if (rc != 0)
+    {
+        // Successfully got domain\username format
+        // Copy to userId buffer, truncating if necessary to MQ_USER_ID_LENGTH (12)
+        strncpy(userId, fullUserId, MQ_USER_ID_LENGTH);
+        userId[MQ_USER_ID_LENGTH] = 0;
+        setUserId(mqmd);
+    }
+    else
+    {
+        // Fallback to simple username if GetUserNameEx fails
+        // This handles cases where domain info is not available
+        DWORD simpleUserIdSize = sizeof(userId);
+        rc = GetUserName(userId, &simpleUserIdSize);
+        if (rc != 0)
+        {
+            userId[MQ_USER_ID_LENGTH] = 0;
+            setUserId(mqmd);
+        }
+    }
+}
+```
+
+#### Implementation Notes
+
+1. **Buffer Size:** Increased to 256 bytes to accommodate full domain\username
+2. **Fallback Logic:** If `GetUserNameEx` fails, fall back to `GetUserName` for compatibility
+3. **Truncation:** Uses `MQ_USER_ID_LENGTH` constant instead of hardcoded 12
+4. **Safety:** Uses `strncpy` to prevent buffer overflow
+
+### Change 2: Add Required Header
+
+**File:** [`RFHUtil/MQMDPAGE.cpp`](../RFHUtil/MQMDPAGE.cpp)  
+**Location:** Top of file with other includes
+
+#### Add Include
+```cpp
+#include <Secext.h>  // For GetUserNameEx
+```
+
+#### Link Library
+Ensure the project links against `Secur32.lib`:
+- **RFHUtil.vcxproj:** Add to `<AdditionalDependencies>`
+- **Client.vcxproj:** Add to `<AdditionalDependencies>`
+
+```xml
+<AdditionalDependencies>Secur32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+```
+
+## Alternative Implementation Options
+
+### Option A: Environment Variable Control (More Flexible)
+
+Add configuration option to choose username format:
+
+```cpp
+else
+{
+    char fullUserId[256];
+    DWORD fullUserIdSize = sizeof(fullUserId);
+    memset(fullUserId, 0, sizeof(fullUserId));
+    memset(userId, 0, sizeof(userId));
+    
+    // Check if user wants domain-qualified username (default: yes)
+    char* useDomain = getenv("RFHUTIL_USE_DOMAIN_USERNAME");
+    BOOL shouldUseDomain = (useDomain == NULL) || (strcmp(useDomain, "0") != 0);
+    
+    if (shouldUseDomain)
+    {
+        rc = GetUserNameEx(NameSamCompatible, fullUserId, &fullUserIdSize);
+        if (rc != 0)
+        {
+            strncpy(userId, fullUserId, MQ_USER_ID_LENGTH);
+            userId[MQ_USER_ID_LENGTH] = 0;
+            setUserId(mqmd);
+        }
+        else
+        {
+            // Fallback to simple username
+            DWORD simpleUserIdSize = sizeof(userId);
+            rc = GetUserName(userId, &simpleUserIdSize);
+            if (rc != 0)
+            {
+                userId[MQ_USER_ID_LENGTH] = 0;
+                setUserId(mqmd);
+            }
+        }
+    }
+    else
+    {
+        // Use simple username (old broken behavior)
+        DWORD simpleUserIdSize = sizeof(userId);
+        rc = GetUserName(userId, &simpleUserIdSize);
+        if (rc != 0)
+        {
+            userId[MQ_USER_ID_LENGTH] = 0;
+            setUserId(mqmd);
+        }
+    }
+}
+```
+
+**Environment Variable:**
+- `RFHUTIL_USE_DOMAIN_USERNAME=1` (default) - Use domain\username
+- `RFHUTIL_USE_DOMAIN_USERNAME=0` - Use simple username
+
+### Option B: Registry Setting (Windows-Native)
+
+Similar to Option A but using Windows Registry instead of environment variable:
+
+```cpp
+// Read from registry: HKEY_CURRENT_USER\Software\IBM\RFHUtil\UseDomainUsername
+HKEY hKey;
+DWORD useDomain = 1;  // Default to domain-qualified
+DWORD dataSize = sizeof(DWORD);
+
+if (RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\IBM\\RFHUtil", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+{
+    RegQueryValueEx(hKey, "UseDomainUsername", NULL, NULL, (LPBYTE)&useDomain, &dataSize);
+    RegCloseKey(hKey);
+}
+```
+
+## Testing Plan
+
+### Unit Testing
+
+#### Test Case 1: Domain-Qualified Username
+**Setup:**
+- Windows domain environment
+- User logged in as `CONTOSO\bmatt`
+
+**Expected:**
+- `GetUserNameEx` succeeds
+- Username set to `CONTOSO\bmat` (truncated to 12 chars)
+- Authentication succeeds with LDAP
+
+#### Test Case 2: Local Account
+**Setup:**
+- Local Windows account (no domain)
+- User logged in as `bmatt`
+
+**Expected:**
+- `GetUserNameEx` fails gracefully
+- Falls back to `GetUserName`
+- Username set to `bmatt`
+- Authentication behavior depends on LDAP config
+
+#### Test Case 3: Long Username
+**Setup:**
+- Domain: `VERYLONGDOMAIN`
+- Username: `verylongusername`
+- Full: `VERYLONGDOMAIN\verylongusername` (33 chars)
+
+**Expected:**
+- Username truncated to `VERYLONGDOMA` (12 chars)
+- Warning logged about truncation
+- Authentication may fail if LDAP requires full name
+
+### Integration Testing
+
+#### Test Environment Setup
+```
+Queue Manager: QM1
+CHLAUTH: Enabled
+CONNAUTH: SYSTEM.DEFAULT.AUTHINFO.IDPWOS
+Auth Info: LDAP backend
+Test Queue: TEST.QUEUE
+```
+
+#### Test Scenarios
+
+| Scenario | User Type | Expected Result |
+|----------|-----------|-----------------|
+| TS1 | Domain user, LDAP configured | Success |
+| TS2 | Local user, LDAP configured | Depends on LDAP config |
+| TS3 | Domain user, no LDAP | Success (local auth) |
+| TS4 | Username > 12 chars | Truncation warning, may fail |
+
+### Regression Testing
+
+Verify existing functionality still works:
+- [ ] Connection with explicit userid/password (MQCSP)
+- [ ] Connection without userid (default context)
+- [ ] Alternate user authority (MQOO_ALTERNATE_USER_AUTHORITY)
+- [ ] Set User ID checkbox functionality
+- [ ] Set All Context checkbox functionality
+
+## Deployment Considerations
+
+### Backward Compatibility
+
+**Impact:** This change restores the old behavior, so it should improve compatibility with existing LDAP configurations.
+
+**Risk Areas:**
+1. Environments that adapted to the broken behavior
+2. Truncation of long domain\username combinations
+3. Systems without domain (will fall back to simple username)
+
+### Rollout Strategy
+
+1. **Phase 1:** Deploy to test environment
+   - Verify with LDAP-backed queue managers
+   - Test both domain and local accounts
+   - Monitor authentication logs
+
+2. **Phase 2:** Limited production deployment
+   - Deploy to subset of users
+   - Gather feedback on authentication success
+   - Monitor for any new issues
+
+3. **Phase 3:** Full deployment
+   - Roll out to all users
+   - Update documentation
+   - Provide troubleshooting guide
+
+### Documentation Updates
+
+Update the following documentation:
+- [ ] User guide - explain IDPWOS authentication behavior
+- [ ] Troubleshooting guide - add section on authentication issues
+- [ ] Release notes - document the fix
+- [ ] README - mention LDAP/IDPWOS support
+
+## Troubleshooting Guide
+
+### Issue: Authentication Still Fails After Fix
+
+**Possible Causes:**
+1. Username truncated due to long domain name
+2. LDAP expects different username format (e.g., UPN: user@domain.com)
+3. CHLAUTH rules blocking the connection
+4. LDAP server configuration issue
+
+**Diagnostic Steps:**
+1. Enable MQ trace: `strmqtrc -m QM1 -t all`
+2. Check username in trace: Look for MQOPEN/MQPUT calls
+3. Check LDAP server logs for authentication attempts
+4. Verify CHLAUTH rules: `DISPLAY CHLAUTH(*)`
+5. Test with explicit userid in connection dialog
+
+**Workarounds:**
+1. Use explicit userid/password in connection settings
+2. Set environment variable `RFHUTIL_USE_DOMAIN_USERNAME=0` (if Option A implemented)
+3. Modify LDAP to accept simple usernames
+4. Adjust CHLAUTH rules to allow the user
+
+### Issue: GetUserNameEx Fails
+
+**Possible Causes:**
+1. Not in a domain environment
+2. Secur32.lib not linked
+3. Windows version too old (pre-XP)
+
+**Solution:**
+- Code automatically falls back to `GetUserName()`
+- Verify fallback logic is working
+- Check application event log for errors
+
+## Code Review Checklist
+
+- [ ] `GetUserNameEx` properly declared with `#include <Secext.h>`
+- [ ] `Secur32.lib` added to linker dependencies
+- [ ] Buffer sizes adequate (256 bytes for full username)
+- [ ] Proper null termination of strings
+- [ ] Fallback logic handles `GetUserNameEx` failure
+- [ ] Truncation uses `MQ_USER_ID_LENGTH` constant
+- [ ] No buffer overflows possible
+- [ ] Error handling for all API calls
+- [ ] Trace logging added for debugging
+- [ ] Comments explain the domain-qualified username requirement
+
+## Success Criteria
+
+- [ ] Authentication succeeds with LDAP-backed IDPWOS
+- [ ] Domain-qualified username sent to MQ
+- [ ] Fallback works for non-domain environments
+- [ ] No regression in existing authentication methods
+- [ ] All unit tests pass
+- [ ] All integration tests pass
+- [ ] Documentation updated
+
+## Timeline Estimate
+
+- **Code Changes:** 2-4 hours
+- **Unit Testing:** 4-6 hours
+- **Integration Testing:** 8-12 hours
+- **Documentation:** 2-4 hours
+- **Code Review:** 2-3 hours
+- **Total:** 18-29 hours (2.5-4 days)
+
+## References
+
+- [IDPWOS Authentication Issue Analysis](IDPWOS_AUTHENTICATION_ISSUE.md)
+- [GetUserNameEx Documentation](https://docs.microsoft.com/en-us/windows/win32/api/secext/nf-secext-getusernameexa)
+- [MQ Security Documentation](https://www.ibm.com/docs/en/ibm-mq/latest?topic=security-channel-authentication-records)
+- [LDAP Authentication in MQ](https://www.ibm.com/docs/en/ibm-mq/latest?topic=mechanisms-ldap-authentication)

--- a/docs/IDPWOS_ISSUE.md
+++ b/docs/IDPWOS_ISSUE.md
@@ -1,0 +1,73 @@
+# IDPWOS Issue: MQCSP Attached with User ID but No Password
+
+## Problem
+
+When a user ID is entered in RFHUtil but no password is provided, and the queue manager has
+`CHCKCLNT(OPTIONAL)` configured, the connection fails with **AMQ5534E**.
+
+### Root Cause
+
+The original code unconditionally populated the `MQCSP` structure and set `SecurityParmsPtr`
+on the `MQCNO` whenever a user ID was present — regardless of whether a password was also
+supplied. Under `CHCKCLNT(OPTIONAL)`, IBM MQ only skips the authentication check when **no
+`MQCSP` is attached at all**. Attaching an `MQCSP` with a non-empty user ID but an empty
+password causes MQ to attempt authentication and fail.
+
+## Fix
+
+**File:** `RFHUtil/DataArea.cpp` — function `DataArea::connect2QM`
+
+The MQCSP setup is now guarded so that `AuthenticationType`, `CSPPasswordPtr`,
+`CSPPasswordLength`, and `SecurityParmsPtr` are only set when a **non-empty password**
+accompanies the user ID.
+
+When a user ID is present but no password is given:
+- The `MQCSP` fields remain at their zero-initialised defaults.
+- `SecurityParmsPtr` is **not** set on the `MQCNO`.
+- The connection proceeds without an authentication challenge.
+
+### Code Change (before → after)
+
+**Before** — password length and pointer were set unconditionally:
+
+```cpp
+csp.CSPPasswordLength = m_conn_password.GetLength();
+csp.CSPPasswordPtr    = (void *)((LPCTSTR)m_conn_password);
+csp.AuthenticationType = MQCSP_AUTH_USER_ID_AND_PWD;
+cno.SecurityParmsPtr   = &csp;
+if (cno.Version < MQCNO_VERSION_5)
+    cno.Version = MQCNO_VERSION_5;
+```
+
+**After** — MQCSP is only activated when a password is present:
+
+```cpp
+int pwdlen = m_conn_password.GetLength();
+if (pwdlen > 0)
+{
+    csp.CSPPasswordLength  = pwdlen;
+    csp.CSPPasswordPtr     = (void *)((LPCTSTR)m_conn_password);
+    csp.AuthenticationType = MQCSP_AUTH_USER_ID_AND_PWD;
+    cno.SecurityParmsPtr   = &csp;
+    if (cno.Version < MQCNO_VERSION_5)
+        cno.Version = MQCNO_VERSION_5;
+}
+```
+
+## Behaviour Matrix
+
+| User ID | Password | MQCSP attached | Expected outcome                        |
+|---------|----------|----------------|-----------------------------------------|
+| empty   | empty    | No             | Anonymous connect (as before)           |
+| set     | empty    | No             | Connect without auth challenge (fixed)  |
+| set     | set      | Yes            | Full user-ID/password authentication    |
+
+## Affected Binaries (rebuilt)
+
+- `bin/Release/rfhutil.exe`
+- `bin/Release/rfhutilc.exe`
+- `bin/ReleaseSafe/rfhutilc-safe.exe`
+
+## Commit
+
+`830190d` — fix: only attach MQCSP when both user ID and password are provided

--- a/docs/IDPWOS_TESTING_GUIDE.md
+++ b/docs/IDPWOS_TESTING_GUIDE.md
@@ -1,0 +1,516 @@
+# IDPWOS Authentication Fix - Testing Guide
+
+## Overview
+
+This guide provides comprehensive testing procedures to verify the IDPWOS authentication fix works correctly across different environments and scenarios.
+
+**Related Documents:**
+- [Issue Analysis](IDPWOS_AUTHENTICATION_ISSUE.md)
+- [Implementation Plan](IDPWOS_FIX_IMPLEMENTATION_PLAN.md)
+
+## Test Environment Requirements
+
+### Minimum Test Environment
+
+#### Queue Manager Configuration
+```
+Queue Manager: QM_TEST
+MQ Version: 8.0 or later
+CHLAUTH: Enabled
+CONNAUTH: SYSTEM.DEFAULT.AUTHINFO.IDPWOS
+```
+
+#### LDAP Configuration
+```
+Auth Info Object: SYSTEM.DEFAULT.AUTHINFO.IDPWOS
+LDAP Server: Active Directory or OpenLDAP
+Base DN: DC=contoso,DC=com
+User Format: DOMAIN\username or username@domain.com
+```
+
+#### Test Queues
+```
+TEST.AUTH.QUEUE - For basic authentication tests
+TEST.AUTH.SECURE - For CHLAUTH rule tests
+TEST.AUTH.ADMIN - For admin authority tests
+```
+
+### Test User Accounts
+
+| Account Type | Username | Domain | Purpose |
+|-------------|----------|--------|---------|
+| Domain User | testuser1 | CONTOSO | Standard domain authentication |
+| Domain User | testuser2 | CONTOSO | Alternative domain user |
+| Local User | localuser | (none) | Non-domain authentication |
+| Long Name | verylongusername | VERYLONGDOMAIN | Truncation testing |
+| Admin User | mqadmin | CONTOSO | Administrative operations |
+
+## Pre-Test Verification
+
+### 1. Verify Old Version Behavior
+
+**Purpose:** Establish baseline of working authentication
+
+**Steps:**
+1. Use old RFHUtil C version (rfhutilc.exe from backup)
+2. Connect to queue manager with IDPWOS enabled
+3. Enable "Set User ID" checkbox on General tab
+4. Put a message to TEST.AUTH.QUEUE
+5. Verify message is accepted
+
+**Expected Result:**
+- Connection succeeds
+- Message put succeeds
+- MQMD UserIdentifier shows domain\username
+
+**Capture:**
+```
+MQ Trace: strmqtrc -m QM_TEST -t all
+LDAP Logs: Check authentication attempts
+RFHUtil Trace: Enable via rfhTrace.cmd
+```
+
+### 2. Verify Broken Behavior
+
+**Purpose:** Confirm the issue exists in current version
+
+**Steps:**
+1. Use current RFHUtil version (before fix)
+2. Repeat steps from Pre-Test 1
+
+**Expected Result:**
+- Connection may succeed
+- Message put fails with authentication error
+- MQMD UserIdentifier shows username without domain
+
+**Error Codes to Watch:**
+- MQRC_NOT_AUTHORIZED (2035)
+- MQRC_SECURITY_ERROR (2063)
+
+## Test Cases
+
+### TC1: Basic Domain Authentication
+
+**Objective:** Verify domain-qualified username is sent correctly
+
+**Prerequisites:**
+- Domain user account (CONTOSO\testuser1)
+- LDAP configured and accessible
+- CHLAUTH rules allow the user
+
+**Test Steps:**
+1. Launch fixed RFHUtil version
+2. Connect to QM_TEST
+3. Navigate to General tab
+4. Check "Set User ID" checkbox
+5. Navigate to MQMD tab
+6. Leave User ID field empty (to use Windows username)
+7. Navigate to Data tab
+8. Enter test message: "Test message 1"
+9. Click "Write Q" button
+10. Enable MQ trace before step 9
+11. Check trace for username format
+
+**Expected Results:**
+- ✓ Connection succeeds
+- ✓ Message written successfully
+- ✓ MQMD UserIdentifier contains "CONTOSO\test" (truncated to 12 chars)
+- ✓ LDAP logs show successful authentication
+- ✓ No MQRC_NOT_AUTHORIZED errors
+
+**Verification:**
+```bash
+# Check message on queue
+echo "DISPLAY QSTATUS(TEST.AUTH.QUEUE) CURDEPTH" | runmqsc QM_TEST
+
+# Browse message and check MQMD
+# Use RFHUtil to browse and verify UserIdentifier field
+```
+
+### TC2: Local Account Fallback
+
+**Objective:** Verify fallback to simple username for non-domain accounts
+
+**Prerequisites:**
+- Local user account (localuser)
+- Logged in as local user
+- LDAP may or may not accept simple usernames
+
+**Test Steps:**
+1. Log in to Windows as localuser
+2. Launch fixed RFHUtil
+3. Connect to QM_TEST
+4. Enable "Set User ID"
+5. Attempt to write message
+
+**Expected Results:**
+- ✓ GetUserNameEx fails (no domain)
+- ✓ Falls back to GetUserName
+- ✓ Username set to "localuser"
+- ✓ Authentication result depends on LDAP configuration
+  - If LDAP accepts simple names: Success
+  - If LDAP requires domain: Fails with MQRC_NOT_AUTHORIZED
+
+**Note:** This is expected behavior - local accounts may not work with LDAP
+
+### TC3: Long Username Truncation
+
+**Objective:** Verify proper handling of usernames exceeding 12 characters
+
+**Prerequisites:**
+- Domain user with long name (VERYLONGDOMAIN\verylongusername)
+- Total length > 12 characters
+
+**Test Steps:**
+1. Log in as long username user
+2. Launch fixed RFHUtil
+3. Enable MQ trace
+4. Connect and write message with "Set User ID" enabled
+5. Check trace for actual username sent
+
+**Expected Results:**
+- ✓ Username truncated to 12 characters
+- ✓ Truncation is "VERYLONGDOM" (first 12 chars of domain\username)
+- ✓ Warning logged about truncation (if implemented)
+- ✓ Authentication may fail if LDAP requires full username
+
+**Verification:**
+```
+Check MQ trace for MQOPEN/MQPUT calls
+Look for UserIdentifier field in MQOD/MQMD structures
+```
+
+### TC4: Explicit User ID Override
+
+**Objective:** Verify explicit user ID in MQMD field takes precedence
+
+**Prerequisites:**
+- Domain user logged in
+- Different user ID to specify
+
+**Test Steps:**
+1. Connect to QM_TEST
+2. Enable "Set User ID"
+3. Navigate to MQMD tab
+4. Enter explicit User ID: "TESTUSER2"
+5. Write message
+
+**Expected Results:**
+- ✓ Explicit user ID used instead of Windows username
+- ✓ MQMD UserIdentifier shows "TESTUSER2"
+- ✓ Authentication uses specified user ID
+
+### TC5: Alternate User Authority
+
+**Objective:** Verify alternate user authority with domain username
+
+**Prerequisites:**
+- User has authority to use alternate user ID
+- MQOO_ALTERNATE_USER_AUTHORITY permission granted
+
+**Test Steps:**
+1. Connect to QM_TEST
+2. Navigate to General tab
+3. Check "Alternate User ID" checkbox
+4. Navigate to MQMD tab
+5. Enter alternate user: "CONTOSO\mqadmin"
+6. Write message
+
+**Expected Results:**
+- ✓ Queue opened with MQOO_ALTERNATE_USER_AUTHORITY
+- ✓ Alternate user ID used for authorization
+- ✓ Domain-qualified username accepted
+
+### TC6: Connection User ID (MQCSP)
+
+**Objective:** Verify connection authentication still works independently
+
+**Prerequisites:**
+- Valid connection credentials
+
+**Test Steps:**
+1. Launch RFHUtil
+2. Before connecting, click "Set Conn User" button
+3. Enter userid: "CONTOSO\testuser1"
+4. Enter password: (valid password)
+5. Connect to QM_TEST
+6. Write message WITHOUT "Set User ID" enabled
+
+**Expected Results:**
+- ✓ Connection succeeds using MQCSP
+- ✓ Message written with default context
+- ✓ MQMD UserIdentifier shows connection user or blank
+- ✓ This path is independent of the fix
+
+### TC7: Multiple Message Operations
+
+**Objective:** Verify username handling across multiple operations
+
+**Test Steps:**
+1. Connect with "Set User ID" enabled
+2. Write 10 messages sequentially
+3. Browse messages
+4. Read messages
+5. Verify each operation uses correct username
+
+**Expected Results:**
+- ✓ All operations succeed
+- ✓ Consistent username across operations
+- ✓ No authentication errors
+
+### TC8: Regression - Without Set User ID
+
+**Objective:** Verify normal operation without Set User ID
+
+**Test Steps:**
+1. Connect to QM_TEST
+2. Do NOT enable "Set User ID"
+3. Write messages normally
+
+**Expected Results:**
+- ✓ Messages written successfully
+- ✓ Default context used
+- ✓ No impact from the fix
+
+### TC9: Different Username Formats in LDAP
+
+**Objective:** Test various LDAP username format expectations
+
+**Test Configurations:**
+
+| LDAP Format | Test Username | Expected Result |
+|-------------|---------------|-----------------|
+| DOMAIN\user | CONTOSO\testuser1 | Success |
+| user@domain | testuser1@contoso.com | May fail (format mismatch) |
+| CN=user,OU=... | CN=testuser1,OU=Users,DC=contoso,DC=com | May fail (format mismatch) |
+| Simple username | testuser1 | Depends on LDAP config |
+
+**Note:** The fix provides DOMAIN\username format. If LDAP expects different format, additional configuration may be needed.
+
+### TC10: Cross-Platform Testing
+
+**Objective:** Verify fix works on different Windows versions
+
+**Test Platforms:**
+- Windows 10 (latest)
+- Windows 11
+- Windows Server 2019
+- Windows Server 2022
+
+**For Each Platform:**
+1. Run TC1 (Basic Domain Authentication)
+2. Verify GetUserNameEx availability
+3. Check for any platform-specific issues
+
+## Performance Testing
+
+### PT1: Authentication Performance
+
+**Objective:** Verify no performance degradation
+
+**Test Steps:**
+1. Write 1000 messages with "Set User ID" enabled
+2. Measure time taken
+3. Compare with old version
+4. Compare with version without "Set User ID"
+
+**Expected Results:**
+- ✓ Performance similar to old version
+- ✓ GetUserNameEx adds negligible overhead
+- ✓ No memory leaks
+
+### PT2: Concurrent Users
+
+**Objective:** Verify multiple users can authenticate simultaneously
+
+**Test Steps:**
+1. Launch 10 RFHUtil instances
+2. Each with different domain user
+3. All enable "Set User ID"
+4. All write messages concurrently
+
+**Expected Results:**
+- ✓ All instances authenticate successfully
+- ✓ No username conflicts
+- ✓ Each message has correct user ID
+
+## Security Testing
+
+### ST1: Username Injection
+
+**Objective:** Verify no username injection vulnerabilities
+
+**Test Steps:**
+1. Attempt to set username with special characters
+2. Try: "DOMAIN\user;DROP TABLE"
+3. Try: "DOMAIN\user\x00admin"
+4. Verify proper sanitization
+
+**Expected Results:**
+- ✓ Special characters handled safely
+- ✓ No buffer overflows
+- ✓ No SQL injection (if LDAP uses SQL backend)
+
+### ST2: Password Handling
+
+**Objective:** Verify passwords not logged or exposed
+
+**Test Steps:**
+1. Enable all tracing
+2. Connect with explicit password
+3. Review all log files
+4. Verify password not in clear text
+
+**Expected Results:**
+- ✓ Password not in MQ trace
+- ✓ Password not in RFHUtil trace
+- ✓ Password not in LDAP logs (should be hashed)
+
+## Error Handling Testing
+
+### ET1: LDAP Server Unavailable
+
+**Test Steps:**
+1. Stop LDAP server
+2. Attempt to connect with "Set User ID"
+3. Verify error handling
+
+**Expected Results:**
+- ✓ Graceful error message
+- ✓ No application crash
+- ✓ Clear indication of LDAP issue
+
+### ET2: Invalid Credentials
+
+**Test Steps:**
+1. Use valid username but wrong password
+2. Attempt operations
+
+**Expected Results:**
+- ✓ MQRC_NOT_AUTHORIZED error
+- ✓ Clear error message
+- ✓ No security information leaked
+
+### ET3: GetUserNameEx Failure
+
+**Test Steps:**
+1. Simulate GetUserNameEx failure (if possible)
+2. Verify fallback to GetUserName
+
+**Expected Results:**
+- ✓ Automatic fallback
+- ✓ Operation continues with simple username
+- ✓ Warning logged
+
+## Test Execution Checklist
+
+### Pre-Execution
+- [ ] Test environment configured
+- [ ] Test users created
+- [ ] LDAP server accessible
+- [ ] Queue manager running
+- [ ] Test queues created
+- [ ] Old version backed up
+- [ ] Tracing enabled
+
+### Execution
+- [ ] TC1: Basic Domain Authentication
+- [ ] TC2: Local Account Fallback
+- [ ] TC3: Long Username Truncation
+- [ ] TC4: Explicit User ID Override
+- [ ] TC5: Alternate User Authority
+- [ ] TC6: Connection User ID (MQCSP)
+- [ ] TC7: Multiple Message Operations
+- [ ] TC8: Regression - Without Set User ID
+- [ ] TC9: Different Username Formats
+- [ ] TC10: Cross-Platform Testing
+- [ ] PT1: Authentication Performance
+- [ ] PT2: Concurrent Users
+- [ ] ST1: Username Injection
+- [ ] ST2: Password Handling
+- [ ] ET1: LDAP Server Unavailable
+- [ ] ET2: Invalid Credentials
+- [ ] ET3: GetUserNameEx Failure
+
+### Post-Execution
+- [ ] All test results documented
+- [ ] Issues logged
+- [ ] Performance metrics recorded
+- [ ] Security review completed
+- [ ] Test environment cleaned up
+
+## Test Result Template
+
+```
+Test Case: TC1 - Basic Domain Authentication
+Date: YYYY-MM-DD
+Tester: [Name]
+Environment: [QM name, LDAP server]
+RFHUtil Version: [Version number]
+
+Steps Executed:
+1. [Step 1] - PASS/FAIL
+2. [Step 2] - PASS/FAIL
+...
+
+Results:
+- Expected: [Description]
+- Actual: [Description]
+- Status: PASS/FAIL
+
+Evidence:
+- Screenshot: [filename]
+- Trace file: [filename]
+- LDAP log: [filename]
+
+Issues Found:
+- [Issue 1]
+- [Issue 2]
+
+Notes:
+[Any additional observations]
+```
+
+## Troubleshooting During Testing
+
+### Issue: Authentication Still Fails
+
+**Check:**
+1. Verify fix was applied correctly
+2. Check GetUserNameEx is being called (add debug logging)
+3. Verify Secur32.lib is linked
+4. Check LDAP server logs for username format received
+5. Verify CHLAUTH rules
+
+### Issue: Username Truncated Incorrectly
+
+**Check:**
+1. Verify buffer size (should be 256 bytes)
+2. Check truncation logic uses MQ_USER_ID_LENGTH
+3. Verify strncpy used correctly
+4. Check for off-by-one errors
+
+### Issue: Fallback Not Working
+
+**Check:**
+1. Verify GetUserName called when GetUserNameEx fails
+2. Check return code handling
+3. Verify error logging
+
+## Success Criteria
+
+The fix is considered successful when:
+- ✓ All TC1-TC10 test cases pass
+- ✓ Performance tests show no degradation
+- ✓ Security tests pass
+- ✓ Error handling tests pass
+- ✓ No regression in existing functionality
+- ✓ Works across all supported Windows versions
+- ✓ LDAP authentication succeeds with domain-qualified usernames
+
+## Sign-Off
+
+```
+Test Lead: _________________ Date: _______
+Developer: _________________ Date: _______
+QA Manager: ________________ Date: _______

--- a/docs/P1_3_64BIT_IMPLEMENTATION.md
+++ b/docs/P1_3_64BIT_IMPLEMENTATION.md
@@ -1,0 +1,194 @@
+# P1.3: 64-bit Platform Support Implementation
+
+## Overview
+Successfully added x64 (64-bit) platform support to the mq-rfhutil project, enabling compilation and execution on both 32-bit (Win32) and 64-bit (x64) Windows platforms.
+
+## Implementation Date
+February 23, 2026
+
+## Objectives Achieved
+✅ Add x64 platform configurations to Visual Studio solution and projects  
+✅ Configure x64-specific build settings and library paths  
+✅ Fix MFC message handler signatures for x64 compatibility  
+✅ Update build scripts to support x64 builds  
+✅ Verify successful compilation of all configurations on both platforms  
+
+## Technical Changes
+
+### 1. Solution Configuration (RFHUtil.sln)
+Added x64 platform configurations for all build modes:
+- **Debug|x64**: Development builds with debugging symbols
+- **Release|x64**: Optimized production builds
+- **ReleaseSafe|x64**: Safe mode builds with additional checks
+
+Both RFHUtil and Client projects now support x64 platform.
+
+### 2. Project Build Settings
+
+#### RFHUtil Project (RFHUtil/RFHUtil.vcxproj)
+- **Output Directory**: `bin\Release\x64\rfhutil.exe`
+- **Library Path**: `d:\apps\mq\tools\lib64` (IBM MQ 9.4.5 x64 libraries)
+- **Preprocessor**: Changed from `WIN32` to `_WIN64`
+- **Platform Toolset**: v143 (Visual Studio 2022)
+- **Character Set**: Unicode
+
+#### Client Project (Client/Client.vcxproj)
+Added x64 configurations for all three modes:
+- **Release|x64**: `bin\Release\x64\rfhutilc.exe`
+- **ReleaseSafe|x64**: `bin\ReleaseSafe\x64\rfhutilc-safe.exe`
+- **Debug|x64**: `bin\Debug\x64\rfhutilc.exe`
+
+Same lib64 path and preprocessor settings as RFHUtil project.
+
+### 3. MFC Message Handler Compatibility Fixes
+
+#### Problem
+MFC's `ON_MESSAGE` macro requires different function signatures for x64 builds. The original Win32 signatures using `LONG` and `UINT` are incompatible with x64 where `WPARAM` and `LPARAM` are 64-bit types.
+
+#### Solution
+Updated 16 message handler function signatures from:
+```cpp
+LONG OnSetPageFocus(UINT wParam, LONG lParam);
+LONG OnUserClose(UINT wParam, LONG lParam);
+```
+
+To x64-compatible signatures:
+```cpp
+LRESULT OnSetPageFocus(WPARAM wParam, LPARAM lParam);
+LRESULT OnUserClose(WPARAM wParam, LPARAM lParam);
+```
+
+#### Files Modified (32 files total)
+
+**Header Files (16 files):**
+1. [`RFHUtil/CapPubs.h`](../RFHUtil/CapPubs.h:102) - OnUserClose
+2. [`RFHUtil/WritePubs.h`](../RFHUtil/WritePubs.h:109) - OnUserClose
+3. [`RFHUtil/CICS.h`](../RFHUtil/CICS.h) - OnSetPageFocus
+4. [`RFHUtil/Dlq.h`](../RFHUtil/Dlq.h) - OnSetPageFocus
+5. [`RFHUtil/General.h`](../RFHUtil/General.h) - OnSetPageFocus
+6. [`RFHUtil/Ims.h`](../RFHUtil/Ims.h) - OnSetPageFocus
+7. [`RFHUtil/jms.h`](../RFHUtil/jms.h) - OnSetPageFocus
+8. [`RFHUtil/MQMDPAGE.h`](../RFHUtil/MQMDPAGE.h) - OnSetPageFocus
+9. [`RFHUtil/MSGDATA.h`](../RFHUtil/MSGDATA.h) - OnSetPageFocus
+10. [`RFHUtil/other.h`](../RFHUtil/other.h) - OnSetPageFocus
+11. [`RFHUtil/Props.h`](../RFHUtil/Props.h) - OnSetPageFocus
+12. [`RFHUtil/PS.h`](../RFHUtil/PS.h) - OnSetPageFocus
+13. [`RFHUtil/pscr.h`](../RFHUtil/pscr.h) - OnSetPageFocus
+14. [`RFHUtil/PubSub.h`](../RFHUtil/PubSub.h) - OnSetPageFocus
+15. [`RFHUtil/RFH.h`](../RFHUtil/RFH.h) - OnSetPageFocus
+16. [`RFHUtil/Usr.h`](../RFHUtil/Usr.h) - OnSetPageFocus
+
+**Implementation Files (16 files):**
+1. [`RFHUtil/CapPubs.cpp`](../RFHUtil/CapPubs.cpp:547) - OnUserClose
+2. [`RFHUtil/WritePubs.cpp`](../RFHUtil/WritePubs.cpp) - OnUserClose
+3. [`RFHUtil/CICS.cpp`](../RFHUtil/CICS.cpp) - OnSetPageFocus
+4. [`RFHUtil/Dlq.cpp`](../RFHUtil/Dlq.cpp) - OnSetPageFocus
+5. [`RFHUtil/General.cpp`](../RFHUtil/General.cpp) - OnSetPageFocus
+6. [`RFHUtil/Ims.cpp`](../RFHUtil/Ims.cpp) - OnSetPageFocus
+7. [`RFHUtil/jms.cpp`](../RFHUtil/jms.cpp) - OnSetPageFocus
+8. [`RFHUtil/MQMDPAGE.cpp`](../RFHUtil/MQMDPAGE.cpp) - OnSetPageFocus
+9. [`RFHUtil/MSGDATA.cpp`](../RFHUtil/MSGDATA.cpp) - OnSetPageFocus
+10. [`RFHUtil/other.cpp`](../RFHUtil/other.cpp:863) - OnSetPageFocus
+11. [`RFHUtil/Props.cpp`](../RFHUtil/Props.cpp:161) - OnSetPageFocus (CProps class)
+12. [`RFHUtil/PS.cpp`](../RFHUtil/PS.cpp:1303) - OnSetPageFocus (CPS class)
+13. [`RFHUtil/pscr.cpp`](../RFHUtil/pscr.cpp:317) - OnSetPageFocus
+14. [`RFHUtil/PubSub.cpp`](../RFHUtil/PubSub.cpp:1727) - OnSetPageFocus
+15. [`RFHUtil/RFH.cpp`](../RFHUtil/RFH.cpp:868) - OnSetPageFocus
+16. [`RFHUtil/Usr.cpp`](../RFHUtil/Usr.cpp:715) - OnSetPageFocus
+
+### 4. Build Script Enhancements (build.cmd)
+
+Added new x64 build commands:
+```batch
+rfhutil-x64    - Build RFHUtil for x64
+client-x64     - Build Client for x64
+safe-x64       - Build Client Safe Mode for x64
+all-x64        - Build all projects for x64
+all-both       - Build all projects for both Win32 and x64
+```
+
+### 5. Version Control (.gitignore)
+
+Added x64 output directories:
+```
+bin/Debug/x64/
+bin/Release/x64/
+bin/ReleaseSafe/x64/
+```
+
+## Build Results
+
+### Successful Builds
+All configurations built successfully with exit code 0:
+
+**Win32 Platform:**
+- ✅ `bin/Release/rfhutil.exe` (RFHUtil Release)
+- ✅ `bin/Release/rfhutilc.exe` (Client Release)
+- ✅ `bin/ReleaseSafe/rfhutilc-safe.exe` (Client Safe Mode)
+
+**x64 Platform:**
+- ✅ `bin/Release/x64/rfhutil.exe` (RFHUtil Release)
+- ✅ `bin/Release/x64/rfhutilc.exe` (Client Release)
+- ✅ `bin/ReleaseSafe/x64/rfhutilc-safe.exe` (Client Safe Mode)
+
+### Compiler Warnings
+Both platforms compile with warnings (non-critical):
+- **C4244**: Type conversion warnings (INT_PTR to int, __int64 to int)
+- **C4267**: size_t conversion warnings
+- **C4311/C4302**: Pointer truncation warnings (expected in x64)
+- **C4477**: sprintf format string warnings
+
+These warnings are expected when porting to 64-bit and do not affect functionality. They can be addressed in future optimization phases if needed.
+
+## Technical Notes
+
+### WPARAM and LPARAM Sizes
+- **Win32**: Both are 32-bit (4 bytes)
+- **x64**: Both are 64-bit (8 bytes)
+
+### LRESULT Return Type
+- Compatible with both Win32 and x64
+- Automatically adjusts to platform pointer size
+
+### IBM MQ Library Paths
+- **Win32**: `d:\apps\mq\tools\lib` (32-bit MQ libraries)
+- **x64**: `d:\apps\mq\tools\lib64` (64-bit MQ libraries)
+
+## Dependencies
+
+### Required Software
+- Visual Studio 2022 (v143 platform toolset)
+- IBM MQ 9.4.5 Client (both 32-bit and 64-bit libraries)
+- Windows SDK 10.0
+
+### MFC Requirements
+- Microsoft Foundation Classes (MFC) for both Win32 and x64
+- Unicode character set support
+
+## Testing Recommendations
+
+1. **Functional Testing**: Verify all MQ operations work correctly on x64
+2. **Performance Testing**: Compare Win32 vs x64 performance
+3. **Memory Testing**: Verify no memory leaks in x64 builds
+4. **Compatibility Testing**: Test with IBM MQ 9.4.5 x64 client libraries
+
+## Future Considerations
+
+### Potential Optimizations
+1. Address remaining compiler warnings (C4244, C4267, C4311, C4302, C4477)
+2. Review pointer arithmetic for x64 safety
+3. Consider using `size_t` instead of `int` for size-related variables
+4. Update sprintf calls to use safer alternatives (sprintf_s)
+
+### Platform-Specific Features
+- Consider leveraging x64-specific optimizations
+- Evaluate memory usage improvements in x64
+- Test with large message payloads (>4GB) on x64
+
+## Related Documentation
+- [Build Configuration Guide](BUILD_CONFIG.md)
+- [Architecture Analysis](ARCHITECTURE_ANALYSIS.md)
+- [Modernization Roadmap](../MODERNIZATION_ROADMAP.md)
+
+## Conclusion
+P1.3 successfully adds comprehensive 64-bit platform support to mq-rfhutil. The project now builds and runs on both Win32 and x64 platforms, providing users with flexibility in deployment options and enabling future enhancements that leverage 64-bit capabilities.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,114 @@
+# RFHUtil Documentation
+
+This folder contains detailed technical documentation for the mq-rfhutil project.
+
+## 📚 Documentation Index
+
+### Architecture & Analysis
+- **[Architecture Analysis](ARCHITECTURE_ANALYSIS.md)** - Comprehensive analysis of the codebase structure, patterns, and design
+- **[Test Environment Info](TEST_ENVIRONMENT_INFO.md)** - Information about the test environment and setup
+
+### Build & Configuration
+- **[Build Configuration](BUILD_CONFIG.md)** - MSBuild paths, build commands, and project structure
+- **[Unit Testing](UNIT_TESTING.md)** - Test framework, running tests, modules under test, adding new tests
+
+### IBM MQ Technical Details
+- **[MQ HeartBeat Negotiation](MQ_HEARTBEAT_NEGOTIATION.md)** - How MQ HeartBeat negotiation works
+- **[MQ HeartBeat vs KeepAlive](MQ_HEARTBEAT_VS_KEEPALIVE.md)** - Comparison and use cases
+- **[MQ KeepAlive Detailed](MQ_KEEPALIVE_DETAILED.md)** - Deep dive into TCP KeepAlive configuration
+
+### Implementation Plans
+
+#### Completed ✅
+- **[P0 Implementation Plan](P0_IMPLEMENTATION_PLAN.md)** - Overall plan for P0 priorities
+- **[P0.2 & P0.3 Implementation Guide](P0_2_AND_P0_3_IMPLEMENTATION_GUIDE.md)** - Detailed guide for auto-reconnect and UI tab
+- **[P1.2 Dark Mode Implementation](P1_2_DARK_MODE_IMPLEMENTATION.md)** - Complete plan for dark mode support
+- **[P1.2 Visual Polish Plan](P1_2_DARK_MODE_VISUAL_POLISH.md)** - Phase 4 visual improvements
+- **[P1.2 README Update Plan](P1_2_README_UPDATE_PLAN.md)** - Documentation updates
+
+#### In Progress 🚧
+- None currently
+
+## 🎯 Quick Links
+
+### For Developers
+- Start with [Architecture Analysis](ARCHITECTURE_ANALYSIS.md) to understand the codebase
+- Check [Build Configuration](BUILD_CONFIG.md) for build instructions
+- Review implementation plans before starting new features
+
+### For MQ Experts
+- [MQ HeartBeat vs KeepAlive](MQ_HEARTBEAT_VS_KEEPALIVE.md) - Understanding the differences
+- [MQ KeepAlive Detailed](MQ_KEEPALIVE_DETAILED.md) - Advanced configuration
+
+### For Project Planning
+- See main [Modernization Roadmap](../MODERNIZATION_ROADMAP.md) for overall progress
+- Check individual implementation plans for detailed task breakdowns
+
+## 📝 Document Status
+
+| Document | Status | Last Updated |
+|----------|--------|--------------|
+| Architecture Analysis | ✅ Complete | Feb 2026 |
+| Build Configuration | ✅ Complete | Feb 14, 2026 |
+| Unit Testing | ✅ Complete | Mar 21, 2026 |
+| MQ HeartBeat Negotiation | ✅ Complete | Feb 2026 |
+| MQ HeartBeat vs KeepAlive | ✅ Complete | Feb 2026 |
+| MQ KeepAlive Detailed | ✅ Complete | Feb 2026 |
+| P0 Implementation Plan | ✅ Complete | Feb 2026 |
+| P0.2 & P0.3 Guide | ✅ Complete | Feb 2026 |
+| P1.2 Dark Mode Plan | ✅ Complete | Feb 16, 2026 |
+| P1.2 Visual Polish Plan | ✅ Complete | Feb 16, 2026 |
+| P1.2 README Update Plan | ✅ Complete | Feb 21, 2026 |
+| Test Environment Info | ✅ Complete | Feb 2026 |
+
+## 🔄 Contributing to Documentation
+
+When adding new documentation:
+
+1. **Place it in this folder** - Keep root directory clean
+2. **Update this README** - Add your document to the index
+3. **Use clear naming** - Follow pattern: `CATEGORY_TOPIC.md`
+4. **Link from roadmap** - Update main roadmap if it's an implementation plan
+5. **Keep it current** - Update "Last Updated" dates
+
+## 📋 Documentation Standards
+
+- Use Markdown format (`.md`)
+- Include table of contents for long documents
+- Add code examples where applicable
+- Use clear headings and sections
+- Include diagrams when helpful (Mermaid or ASCII art)
+- Keep technical accuracy high
+- Update when implementation changes
+
+## 🏗️ Project Structure
+
+```
+mq-rfhutil/
+├── README.md                      # Main project readme
+├── MODERNIZATION_ROADMAP.md       # Overall modernization plan
+├── CHANGELOG.md                   # Version history
+├── docs/                          # ← You are here
+│   ├── README.md                  # This file
+│   ├── ARCHITECTURE_ANALYSIS.md
+│   ├── BUILD_CONFIG.md
+│   ├── MQ_*.md                    # MQ technical docs
+│   ├── P0_*.md                    # P0 implementation docs
+│   └── P1_*.md                    # P1 implementation docs
+├── RFHUtil/                       # Main application source
+├── Client/                        # Client version source
+└── mqperf/                        # Performance testing tools
+```
+
+## 📞 Questions?
+
+For questions about:
+- **Architecture** - See [Architecture Analysis](ARCHITECTURE_ANALYSIS.md)
+- **Building** - See [Build Configuration](BUILD_CONFIG.md)
+- **MQ Configuration** - See MQ technical docs
+- **Implementation** - See relevant implementation plan
+
+---
+
+**Last Updated:** February 14, 2026  
+**Maintained By:** Development Team

--- a/docs/TEST_ENVIRONMENT_INFO.md
+++ b/docs/TEST_ENVIRONMENT_INFO.md
@@ -1,0 +1,474 @@
+# Test Environment Information
+
+## Available Test Queue Manager
+
+### Connection Details
+
+**Queue Manager:** QM1 (Docker container)
+**Host:** localhost
+**Port:** 1414
+**Channel:** DEV.APP.SVRCONN
+**Transport:** TCP
+
+#### Authentication (Secured Setup)
+**Username:** mqapp
+**Password:** securePassword123
+
+#### Available Queues
+- **TEST.HELLO.WORLD.Q1** - Test queue (from screenshot)
+- **DEV.INPUT.QUEUE** - Input queue
+- **DEV.OUTPUT.QUEUE** - Output queue
+
+#### Connection Strings
+
+**Without Authentication:**
+```
+DEV.APP.SVRCONN/TCP/localhost
+```
+
+**With Authentication (Recommended):**
+```
+Queue Manager: QM1
+Channel: DEV.APP.SVRCONN
+Host: localhost
+Port: 1414
+User: mqapp
+Password: securePassword123
+```
+
+### Screenshot Analysis
+
+From the RFHUtil screenshot, I can see:
+
+1. **Successfully Connected:**
+   - Queue Manager: `DEV.APP.SVRCONN/TCP/localhost`
+   - Queue Name: `TEST.HELLO.WORLD.Q1`
+   - Remote Queue Manager: `QM1`
+   - Queue Type: Local
+   - Queue Depth: 0 (empty)
+
+2. **Connection Method:**
+   - Using client channel: `DEV.APP.SVRCONN`
+   - Transport: TCP/IP
+   - Host: localhost (Docker container)
+   - Port: 1414
+   - Authentication: User ID and password (mqapp/securePassword123)
+
+3. **Application Status:**
+   - Multiple "No messages in queue" entries at 14:14:40-41 2033
+   - Connection is active and working
+   - Can browse queue successfully
+
+### Test Environment Setup
+
+This provides an excellent test environment for:
+
+1. **Testing Connection Improvements:**
+   - Can test HeartBeat/KeepAlive configuration
+   - Can simulate connection failures
+   - Can verify automatic reconnection
+
+2. **Testing Message Operations:**
+   - Put messages to TEST.HELLO.WORLD.Q1
+   - Get messages from queue
+   - Browse messages
+   - Test various message formats
+
+3. **Testing Channel Configuration:**
+   - Verify channel settings
+   - Test SSL/TLS (if configured)
+   - Test different connection options
+
+### Docker Container Information
+
+**Actual Setup:**
+```bash
+# IBM MQ Docker setup with authentication
+docker run -d \
+  --name qm1 \
+  -p 1414:1414 \
+  -p 9443:9443 \
+  -e LICENSE=accept \
+  -e MQ_QMGR_NAME=QM1 \
+  -e MQ_APP_PASSWORD=securePassword123 \
+  ibmcom/mq:latest
+```
+
+**Configured Channels:**
+- `DEV.APP.SVRCONN` - Application channel (with authentication)
+- `DEV.ADMIN.SVRCONN` - Admin channel
+
+**Configured Queues:**
+- `TEST.HELLO.WORLD.Q1` - Test queue
+- `DEV.INPUT.QUEUE` - Input queue for testing
+- `DEV.OUTPUT.QUEUE` - Output queue for testing
+- `DEV.QUEUE.1`, `DEV.QUEUE.2`, `DEV.QUEUE.3` - Default queues
+
+**Authentication:**
+- User: `mqapp`
+- Password: `securePassword123`
+- Authentication Type: User ID and Password (MQCSP)
+
+### Testing Recommendations
+
+#### 1. Test Current Behavior (Baseline)
+
+**Test HeartBeat/KeepAlive defaults:**
+```
+1. Connect to QM1 via DEV.APP.SVRCONN/TCP/localhost
+   - Use credentials: mqapp / securePassword123
+2. Leave connection idle for 5+ minutes
+3. Observe if connection stays alive
+4. Try to put/get message to DEV.INPUT.QUEUE after idle period
+5. Document any timeouts or failures
+```
+
+**RFHUtil Connection Setup:**
+```
+1. Open RFHUtil
+2. Queue Manager Name: QM1
+3. Click "Set Conn Id" button
+4. Enter User ID: mqapp
+5. Enter Password: securePassword123
+6. Click OK
+7. Click "Connect" (or use MQ menu → MQCONN)
+8. Select Queue: DEV.INPUT.QUEUE or DEV.OUTPUT.QUEUE
+```
+
+**Expected Results (Current Code):**
+- HeartBeat: 300s (5 minutes) - default
+- KeepAlive: OS default (~7200s / 2 hours)
+- May experience firewall timeouts if any
+
+#### 2. Test Improved Configuration
+
+**After adding HeartBeat/KeepAlive:**
+```cpp
+cd.HeartBeatInterval = 60;
+cd.KeepAliveInterval = MQKAI_AUTO;
+```
+
+**Test Procedure:**
+```
+1. Rebuild RFHUtil with new configuration
+2. Connect to QM1
+3. Leave idle for 5+ minutes
+4. Verify heartbeats are sent (check MQ logs)
+5. Verify connection stays alive
+6. Test message operations after idle period
+```
+
+**Expected Results:**
+- HeartBeat every 60 seconds
+- Connection stays alive indefinitely
+- No timeouts
+- Fast failure detection if QM stops
+
+#### 3. Test Automatic Reconnection
+
+**Simulate Connection Failure:**
+```
+1. Connect to QM1 with credentials (mqapp/securePassword123)
+2. Put a test message to DEV.INPUT.QUEUE
+3. Stop Docker container: docker stop qm1
+4. Observe RFHUtil behavior (should detect failure in ~60s)
+5. Start container: docker start qm1
+6. Verify automatic reconnection
+7. Try to get message from DEV.INPUT.QUEUE
+```
+
+**Expected Results (After Implementation):**
+- Connection failure detected within 60s
+- Automatic retry with backoff (1s, 2s, 4s)
+- Successful reconnection when QM available
+- User sees minimal disruption
+
+#### 4. Test Network Failure
+
+**Simulate Network Issue:**
+```
+1. Connect to QM1 with credentials
+2. Put message to DEV.OUTPUT.QUEUE
+3. Pause Docker container: docker pause qm1
+4. Observe detection time (should be ~60s with improvements)
+5. Unpause: docker unpause qm1
+6. Verify recovery and reconnection
+7. Verify message is still in queue
+```
+
+**Expected Results:**
+- KeepAlive detects network failure
+- Connection closed cleanly
+- Automatic reconnection attempted
+- Success when network restored
+
+### MQ Configuration to Check
+
+**Query Channel Settings:**
+```bash
+# Connect to QM1 container
+docker exec -it qm1 bash
+
+# Run MQSC commands
+echo "DISPLAY CHANNEL(DEV.APP.SVRCONN) HBINT KAINT" | runmqsc QM1
+
+# Check authentication settings
+echo "DISPLAY CHANNEL(DEV.APP.SVRCONN) ALL" | runmqsc QM1
+
+# Check queue definitions
+echo "DISPLAY QUEUE(DEV.INPUT.QUEUE)" | runmqsc QM1
+echo "DISPLAY QUEUE(DEV.OUTPUT.QUEUE)" | runmqsc QM1
+echo "DISPLAY QUEUE(TEST.HELLO.WORLD.Q1)" | runmqsc QM1
+```
+
+**Expected Output:**
+```
+DISPLAY CHANNEL(DEV.APP.SVRCONN)
+...
+HBINT(300)        # Default HeartBeat interval
+KAINT(AUTO)       # Default KeepAlive interval
+...
+```
+
+**Modify Channel for Testing (Optional):**
+```bash
+# Connect to container
+docker exec -it qm1 bash
+
+# Run MQSC
+runmqsc QM1
+
+# Set aggressive heartbeat on server side
+ALTER CHANNEL(DEV.APP.SVRCONN) CHLTYPE(SVRCONN) HBINT(30)
+
+# Or disable to test client-side control
+ALTER CHANNEL(DEV.APP.SVRCONN) CHLTYPE(SVRCONN) HBINT(0)
+
+# Verify changes
+DISPLAY CHANNEL(DEV.APP.SVRCONN) HBINT KAINT
+
+# Exit MQSC
+END
+```
+
+### Test Scenarios Matrix
+
+| Scenario | Client HBINT | Server HBINT | Expected Result |
+|----------|--------------|--------------|-----------------|
+| **Baseline** | Not set (0) | 300 | 300s heartbeat |
+| **Client Control** | 60 | 300 | 60s heartbeat (client wins) |
+| **Server Control** | 60 | 30 | 30s heartbeat (server wins) |
+| **Client Aggressive** | 30 | 300 | 30s heartbeat |
+| **Both Disabled** | 0 | 0 | No heartbeat (risky!) |
+
+### Monitoring and Verification
+
+**Check MQ Logs:**
+```bash
+# View queue manager logs
+docker exec qm1 cat /var/mqm/qmgrs/QM1/errors/AMQERR01.LOG
+
+# Look for:
+# - AMQ9208: HeartBeat interval messages
+# - AMQ9209: KeepAlive interval messages
+# - AMQ9999: Channel status messages
+```
+
+**Enable MQ Trace (if needed):**
+```bash
+# In container
+strmqtrc -m QM1 -t all
+
+# Reproduce issue
+
+# Stop trace
+endmqtrc -m QM1
+
+# View trace
+dmpmqtrc /var/mqm/trace/*.TRC
+```
+
+**RFHUtil Trace:**
+```cmd
+# Set environment variable
+set RFHUTIL_TRACE_FILE=c:\temp\rfhutil.log
+
+# Run RFHUtil
+rfhutilc.exe
+
+# Check log file for connection details
+```
+
+### Performance Baseline
+
+**Measure Current Performance:**
+```
+1. Connect to QM1 with credentials (mqapp/securePassword123)
+2. Select queue: DEV.INPUT.QUEUE
+3. Put 1000 messages (use Load Q feature)
+4. Record time
+5. Get 1000 messages (use Display Q feature)
+6. Record time
+7. Document baseline
+
+Test with different message sizes:
+- Small: 100 bytes
+- Medium: 10 KB
+- Large: 100 KB
+```
+
+**After Improvements:**
+```
+1. Repeat same test
+2. Compare performance
+3. Verify no regression
+4. Document any improvements
+```
+
+### Integration Testing Checklist
+
+**Authentication Tests:**
+- [ ] Connect with valid credentials (mqapp/securePassword123)
+- [ ] Connect with invalid credentials (verify error handling)
+- [ ] Connect without credentials (verify error)
+
+**Basic Operations:**
+- [ ] Put message to DEV.INPUT.QUEUE
+- [ ] Get message from DEV.INPUT.QUEUE
+- [ ] Put message to DEV.OUTPUT.QUEUE
+- [ ] Get message from DEV.OUTPUT.QUEUE
+- [ ] Put message to TEST.HELLO.WORLD.Q1
+- [ ] Browse messages in all queues
+
+**Connection Stability:**
+- [ ] Connection idle for 5+ minutes (with auth)
+- [ ] Connection recovery after QM restart
+- [ ] Connection recovery after network pause
+- [ ] HeartBeat verification (logs)
+- [ ] KeepAlive verification (logs)
+
+**Reconnection Tests:**
+- [ ] Automatic reconnection test
+- [ ] Multiple reconnection attempts
+- [ ] Exponential backoff verification
+- [ ] Reconnection with authentication
+
+**Performance:**
+- [ ] Performance comparison (before/after)
+- [ ] Performance with authentication overhead
+- [ ] Bulk message operations (1000+ messages)
+
+**Error Handling:**
+- [ ] Invalid queue name
+- [ ] Invalid credentials
+- [ ] Network timeout
+- [ ] QM unavailable
+
+### Notes for Implementation
+
+**Connection String Format:**
+```
+Queue Manager Name: QM1
+Channel: DEV.APP.SVRCONN
+Transport: TCP
+Host: localhost
+Port: 1414
+User: mqapp
+Password: securePassword123
+```
+
+**MQSERVER Environment Variable:**
+```cmd
+set MQSERVER=DEV.APP.SVRCONN/TCP/localhost(1414)
+```
+
+**Authentication in RFHUtil:**
+The connection uses MQCSP (Connection Security Parameters) for authentication:
+```cpp
+// In DataArea.cpp connect2QM method
+MQCSP csp = {MQCSP_DEFAULT};
+csp.AuthenticationType = MQCSP_AUTH_USER_ID_AND_PWD;
+csp.CSPUserIdPtr = "mqapp";
+csp.CSPPasswordPtr = "securePassword123";
+cno.SecurityParmsPtr = &csp;
+```
+
+**Alternative Connection Methods:**
+```
+1. MQSERVER environment variable (no auth)
+2. Client Channel Definition Table (CCDT) with auth
+3. Direct connection in RFHUtil with "Set Conn Id" (recommended)
+4. Environment variables for credentials (not recommended for security)
+```
+
+**Security Notes:**
+- ✅ Always use "Set Conn Id" dialog for credentials
+- ✅ Credentials are stored in memory only (not persisted)
+- ✅ Use MQCSP for authentication (modern method)
+- ❌ Don't hardcode credentials in code
+- ❌ Don't use environment variables for passwords
+
+### Docker Commands Reference
+
+**Useful Commands:**
+```bash
+# Check if QM1 is running
+docker ps | grep qm1
+
+# View QM1 logs
+docker logs qm1
+
+# Stop QM1 (graceful)
+docker stop qm1
+
+# Start QM1
+docker start qm1
+
+# Restart QM1
+docker restart qm1
+
+# Pause QM1 (simulate network failure)
+docker pause qm1
+
+# Unpause QM1
+docker unpause qm1
+
+# Execute commands in QM1
+docker exec -it qm1 bash
+
+# Check MQ version
+docker exec qm1 dspmqver
+```
+
+### Expected Test Results Summary
+
+**Current Behavior:**
+- ✅ Can connect to QM1 with authentication
+- ✅ Can put/get messages to DEV.INPUT.QUEUE and DEV.OUTPUT.QUEUE
+- ✅ Authentication working (mqapp/securePassword123)
+- ⚠️ Slow failure detection (300s)
+- ⚠️ No automatic reconnection
+- ⚠️ Potential firewall timeouts
+- ⚠️ Must manually reconnect after failure
+
+**After Improvements:**
+- ✅ Can connect to QM1 with authentication
+- ✅ Can put/get messages to all queues
+- ✅ Authentication working seamlessly
+- ✅ Fast failure detection (60s)
+- ✅ Automatic reconnection (with re-authentication)
+- ✅ No firewall timeouts
+- ✅ Better user experience
+- ✅ Transparent recovery from failures
+
+**Authentication Considerations:**
+- Credentials must be re-supplied on reconnection
+- ConnectionManager should cache credentials securely
+- Automatic reconnection must include authentication
+
+---
+
+**Document Version:** 1.0  
+**Date:** 2026-02-13  
+**Author:** IBM Bob (Architect Mode)  
+**Status:** Test Environment Documented

--- a/docs/UNIT_TESTING.md
+++ b/docs/UNIT_TESTING.md
@@ -1,0 +1,176 @@
+# Unit Testing for mq-rfhutil
+
+## Overview
+
+The unit test suite validates core parsing, encoding, and utility functions using
+Google Test (gtest) v1.8.1.8 via NuGet.  Tests run as a `/SUBSYSTEM:WINDOWS` MFC
+application — there is no console stdout, so results are captured via
+`--gtest_output=xml:<path>`.
+
+## Quick Start
+
+### Build
+
+```bash
+# Win32 Debug
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" ^
+  tests\UnitTests\UnitTests.vcxproj -t:Build -p:Configuration=Debug -p:Platform=Win32 -v:minimal
+
+# x64 Debug
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" ^
+  tests\UnitTests\UnitTests.vcxproj -t:Build -p:Configuration=Debug -p:Platform=x64 -v:minimal
+```
+
+### Run
+
+```powershell
+# PowerShell — runs both platforms and reports results
+.\run_tests.ps1
+
+# Manual — single platform
+bin\tests\UnitTests.exe --gtest_output=xml:results.xml
+```
+
+The exit code is 0 when all tests pass, non-zero on failure.
+
+## Test Summary
+
+| File | Module Under Test | Tests | Coverage Areas |
+|------|-------------------|-------|----------------|
+| `ComsubsTests.cpp` | `comsubs.cpp` | 40 | Hex encoding, EBCDIC conversion, string utilities, byte reversal, integer parsing |
+| `XmlsubsTests.cpp` | `xmlsubs.cpp` | 29 | XML entity escape/unescape, XML validation, delimiter finding, comment/DTD processing, CR/LF removal |
+| `NamesTests.cpp` | `Names.cpp` | 25 | Insert, find, address lookup, iteration, reallocation, statistics |
+| `JsonParseTests.cpp` | `JsonParse.cpp` | 19 | JSON parsing, tree navigation, value verification, `buildParsedArea` round-trip, error handling |
+| `XMLParseTests.cpp` | `XMLParse.cpp` | 19 | XML parsing, tree navigation, `createXML` round-trip, error messages, structural edge cases |
+| **Total** | | **132** | |
+
+## Architecture
+
+### MFC-Hosted Test Runner
+
+The source files under test use MFC types (`CString`, `BOOL`, `AfxGetApp`), so
+the test executable must be a Windows application with a live `CWinApp` object.
+`TestMain.cpp` defines `CTestApp` (subclass of `CRfhutilApp`) which overrides
+`InitInstance()` to run Google Test and then immediately terminates the process.
+
+```
+CTestApp::InitInstance()
+  → testing::InitGoogleTest()
+  → RUN_ALL_TESTS()
+  → TerminateProcess()          // skip CRT atexit cleanup
+```
+
+`TerminateProcess()` is used instead of a normal return to avoid cross-CRT
+shutdown issues between the v143 test exe and the v140 gtest DLLs.
+
+### CRT Compatibility
+
+The gtest NuGet package (`Microsoft.googletest.v140.windesktop.msvcstl.dyn.rt-dyn`)
+ships DLLs compiled with the v140 toolset (VS2015) using `/MDd` (dynamic CRT).
+The test project uses v143 (VS2022).
+
+**Critical configuration:**
+- `UseOfMfc=Dynamic` — uses `/MDd` (dynamic CRT), so the exe shares the same
+  `ucrtbased.dll` heap with the gtest DLLs
+- Using `UseOfMfc=Static` would default to `/MTd` (static CRT = private heap),
+  causing cross-heap corruption and `__acrt_first_block == header` assertion failures
+
+### Stub Headers
+
+The test project uses `prelude.h` (force-included via `/FI`) to stub out MQ SDK
+dependencies (`cmqc.h`, `cmqxp.h`, etc.) so tests compile without the IBM MQ
+SDK installed.  A local `rfhutil.h` provides minimal type definitions needed by
+the source files under test.
+
+### Project Layout
+
+```
+tests/UnitTests/
+├── UnitTests.vcxproj      # MSBuild project (Debug|Win32, Debug|x64)
+├── packages.config         # NuGet: gtest v1.8.1.8
+├── TestMain.cpp            # MFC-hosted gtest entry point
+├── prelude.h               # MQ SDK stubs (force-included)
+├── stdafx.h                # Precompiled header stub
+├── rfhutil.h               # Minimal type stubs
+├── ComsubsTests.cpp        # Tests for comsubs.cpp
+├── XmlsubsTests.cpp        # Tests for xmlsubs.cpp
+├── JsonParseTests.cpp      # Tests for JsonParse.cpp
+├── XMLParseTests.cpp       # Tests for XMLParse.cpp
+└── NamesTests.cpp          # Tests for Names.cpp
+```
+
+### Output Locations
+
+| Platform | Executable | XML Results |
+|----------|-----------|-------------|
+| Win32 | `bin\tests\UnitTests.exe` | `bin\tests\results_win32.xml` |
+| x64 | `bin\tests\x64\UnitTests.exe` | `bin\tests\x64\results_x64.xml` |
+
+## Modules Under Test
+
+### comsubs.cpp — Common Utility Subroutines
+
+Pure functions with no MQ or DataArea dependencies.
+
+- **Hex encoding**: `AsciiToHex`, `HexToAscii`, `checkIfHex`, `charValue`, `fromHex`, `getHexCharValue`
+- **EBCDIC conversion**: `AsciiToEbcdic`, `EbcdicToAscii`, `isUCS2`
+- **String utilities**: `skipWhiteSpace`, `skipBlanks`, `Rtrim`, `findBlank`, `skipQuotedString`, `findcrlf`
+- **Integer parsing**: `my_atoi64`
+- **Byte reversal**: `reverseBytes`, `reverseBytes4`
+
+### xmlsubs.cpp — XML Helper Subroutines
+
+Standalone XML processing functions.
+
+- **Entity handling**: `removeEscSeq` (unescape), `insertEscChars` (escape), `setEscChar`
+- **Validation**: `checkIfXml` (returns 0=valid, non-zero=invalid)
+- **Navigation**: `findDelim` (1-indexed, respects escape char), `findEndBracket`, `findXmlValue`
+- **Structural**: `processComment` (skip `<!-- -->`), `processDTD` (skip `<!DOCTYPE>`), `removeCrLf`
+
+### JsonParse.cpp — JSON Parser
+
+Tree-based JSON parser with element navigation.
+
+- **Parsing**: `parse()` returns `JPARSE_OK` on success
+- **Navigation**: `getFirstChild()`, `getNextSibling()`, `getElemName()`, `getElemValue()`
+- **Output**: `buildParsedArea()` reconstructs JSON from the parse tree
+- **Note**: `getElemValue()` returns string values WITH surrounding double quotes (e.g., `"\"Alice\""`)
+- **Note**: Array elements are stored as the value string, not as navigable children
+
+### XMLParse.cpp — XML Parser
+
+Tree-based XML parser with element navigation.
+
+- **Parsing**: `parse()` returns `PARSE_OK` on success
+- **Navigation**: `getFirstChild()`, `getNextSibling()`, `getElemName()`, `getElemValue()`, `getElemType()`
+- **Output**: `createXML()` reconstructs XML from the parse tree
+- **Error reporting**: `getErrorMsg()` for error codes, `getLastError()` for parse failure details
+
+### Names.cpp — String Name Table
+
+Hash-based name storage with insert, find, and iteration.
+
+- **Insert/Find**: `insertName()` returns handle > 0, `findName()` returns 0 if not found
+- **Address lookup**: `getNameAddr()` returns pointer to stored string
+- **Iteration**: `getFirstEntry()` / `getNextEntry()` — note: internal extra entry included in count
+- **Statistics**: `getInsertCount()`, `getReallocCount()`, `getNameTableSize()`
+- **Reallocation**: Small initial table size forces reallocs, all entries remain valid after realloc
+
+## Adding New Tests
+
+1. Create `<Module>Tests.cpp` in `tests/UnitTests/`
+2. Add the `.cpp` file to the test files `<ItemGroup>` in `UnitTests.vcxproj`
+3. Add the source file under test to the source files `<ItemGroup>` if not already present
+4. Add any required headers to the headers `<ItemGroup>`
+5. Include `"stdafx.h"`, `"rfhutil.h"`, and `<gtest/gtest.h>` at the top
+6. If the source file needs MQ types, add stubs to `prelude.h`
+
+## Known Limitations
+
+- **No MQ SDK tests**: Functions that call MQ APIs (`MQCONN`, `MQPUT`, etc.) cannot
+  be tested without the IBM MQ SDK installed and a running queue manager
+- **No GUI tests**: Dialog-based UI code (`DataArea`, tab pages) is not tested
+- **Parser leniency**: Both JSON and XML parsers are lenient with malformed input —
+  some tests document behavior rather than assert specific error codes
+- **gtest v1.8.1.8**: Older version (v140 NuGet); does not support parameterized
+  test suites or newer gtest features

--- a/tests/IntegrationTests/IntegrationTests.vcxproj
+++ b/tests/IntegrationTests/IntegrationTests.vcxproj
@@ -71,13 +71,13 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;MQCLIENT;_CRT_SECURE_NO_WARNINGS;_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>d:\apps\mq\tools\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MQ_HOME)\tools\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>mqic32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -88,13 +88,13 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>d:\apps\mq\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MQ_HOME)\tools\c\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WIN64;MQCLIENT;_CRT_SECURE_NO_WARNINGS;_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>d:\apps\mq\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(MQ_HOME)\tools\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>mqic.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
## Summary

- Adds `Directory.Build.props` at solution root defining `MQ_HOME` with default `C:\Program Files\IBM\MQ` (standard IBM MQ install location)
- Replaces all hardcoded `d:\apps\mq\` paths in `RFHUtil.vcxproj`, `Client.vcxproj`, and `IntegrationTests.vcxproj` with `$(MQ_HOME)\...`
- Override via environment variable (`set MQ_HOME=<path>`) or MSBuild flag (`/p:MQ_HOME=<path>`)
- Updates `docs/BUILD_CONFIG.md` to document the new mechanism

## Why

Hardcoded developer-machine paths blocked any other contributor from building and were a hard blocker for GitHub Actions CI/CD (P3.2).

## Test plan

- [x] `Release|Win32` — `rfhutil.exe` + `rfhutilc.exe` build clean
- [x] `Release|x64` — `rfhutil.exe` builds clean
- [x] `ReleaseSafe|Win32` — `rfhutilc-safe.exe` builds clean
- [x] All builds verified with `/p:MQ_HOME=d:\apps\mq` override