### PR TITLE
CI: publish release binaries on v* tag (P3.10)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release — Publish Artifacts
+
+# Triggered when a version tag is pushed (e.g. `git tag v9.4.0.0 && git push --tags`).
+# Publishes the committed Release/ReleaseSafe binaries — these can't be built in
+# CI because the runner has no IBM MQ SDK, so we ship what's tracked in the repo
+# at the tagged commit.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish release artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify binaries exist
+        run: |
+          set -e
+          for f in bin/Release/rfhutil.exe bin/Release/rfhutilc.exe bin/ReleaseSafe/rfhutilc-safe.exe; do
+            if [ ! -f "$f" ]; then
+              echo "Missing required binary: $f"
+              exit 1
+            fi
+            ls -la "$f"
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            bin/Release/rfhutil.exe
+            bin/Release/rfhutilc.exe
+            bin/ReleaseSafe/rfhutilc-safe.exe
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/MODERNIZATION_ROADMAP.md
+++ b/MODERNIZATION_ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## 📊 Progress Tracker
 
-**Last Updated:** May 8, 2026 (P3.2–P3.6 complete)
+**Last Updated:** May 8, 2026 (P3.10 complete)
 **Current Version:** 9.4.0.0
 **Build Environment:** Visual Studio 2022 (v143), IBM MQ 9.4.5
 
@@ -27,6 +27,7 @@
 | 🟡 **P3.4** | Expand tests — message encoding | ✅ COMPLETE | May 7, 2026 | EBCDIC, hex, JSON, XML round-trips |
 | 🟡 **P3.5** | Expand tests — connection lifecycle | ✅ COMPLETE | May 7, 2026 | Reconnect eligibility + attempt counter |
 | 🟡 **P3.6** | Expand tests — file I/O round-trips | ✅ COMPLETE | May 7, 2026 | 241 tests across 46 test cases, both platforms green |
+| 🟢 **P3.10** | GitHub Actions — release artifact publishing | ✅ COMPLETE | May 8, 2026 | `release.yml` triggers on `v*` tag push, publishes committed binaries |
 
 ### In Progress 🚧
 
@@ -41,7 +42,6 @@
 | 🟢 **P3.7** | MQ handle RAII wrapper | Small | Medium | Q3 2026 |
 | 🟢 **P3.8** | Human-readable MQ error messages | Small | Medium | Q3 2026 |
 | 🟢 **P3.9** | TLS configuration improvements | Medium | Medium | Q3 2026 |
-| 🟢 **P3.10** | GitHub Actions — release artifact publishing | Small | Medium | Q3 2026 |
 | 🔵 **P4.1** | DataArea refactor — extract `MQConnection` | Medium | High | Q3 2026 |
 | 🔵 **P4.2** | DataArea refactor — extract `MQMessageReader` / `MQMessageWriter` | High | High | Q3 2026 |
 | 🔵 **P4.3** | DataArea refactor — extract `RFHHeaders` | High | High | Q4 2026 |
@@ -89,7 +89,7 @@ This document provides a **detailed, actionable roadmap** for modernizing the mq
 | 🟢 **P3.7** | MQ handle RAII wrapper | Small | Medium | Low | Wrap `MQHOBJ`/`MQHCONN` — prevents leaks on exception paths |
 | 🟢 **P3.8** | Human-readable MQ error messages | Small | Medium | Low | Map reason codes (e.g. RC=2035) to descriptive strings |
 | 🟢 **P3.9** | TLS configuration improvements | Medium | Medium | Medium | Make cipher suite configurable per connection in UI |
-| 🟢 **P3.10** | GitHub Actions — release publishing | Small | Medium | Low | Upload `.exe` artifacts on tag; depends on P3.2 |
+| 🟢 **P3.10** | GitHub Actions — release publishing | Small | Medium | Low | ✅ DONE — `release.yml` publishes committed binaries on `v*` tag |
 
 ### Phase 3: Refactoring (P4) — Requires P3 Safety Net
 
@@ -179,6 +179,6 @@ With CI/CD and tests as safety net:
 
 ---
 
-**Document Version:** 1.3
+**Document Version:** 1.4
 **Date:** 2026-05-08
 **Status:** Active

--- a/docs/BUILD_CONFIG.md
+++ b/docs/BUILD_CONFIG.md
@@ -84,5 +84,24 @@ When built with `ReleaseSafe` configuration:
 
 See [SAFE_MODE_IMPLEMENTATION.md](SAFE_MODE_IMPLEMENTATION.md) for detailed implementation information.
 
+## Cutting a Release
+
+The release workflow (`.github/workflows/release.yml`) triggers on any tag
+matching `v*` and publishes the committed Release/ReleaseSafe binaries.
+
+1. Rebuild and commit Release + ReleaseSafe binaries locally (see build
+   commands above).
+2. Tag and push:
+   ```bash
+   git tag v9.4.0.0
+   git push origin v9.4.0.0
+   ```
+3. The workflow attaches `rfhutil.exe`, `rfhutilc.exe`, and
+   `rfhutilc-safe.exe` to an auto-generated GitHub Release.
+
+The runner has no IBM MQ SDK, so the workflow does not build — it publishes
+what is tracked at the tagged commit. Always rebuild and commit binaries
+before tagging.
+
 ## Current Version
 **9.4.0.0** - Built against IBM MQ 9.4.5


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — triggers on `v*` tag push, attaches `rfhutil.exe` / `rfhutilc.exe` / `rfhutilc-safe.exe` to an auto-generated GitHub Release.
- Documents the tag flow in [docs/BUILD_CONFIG.md](docs/BUILD_CONFIG.md): rebuild binaries locally, commit, tag, push.
- Marks P3.10 complete in [MODERNIZATION_ROADMAP.md](MODERNIZATION_ROADMAP.md).

## Why publish-only, not build-on-tag?
The GitHub runner has no IBM MQ SDK installed, and vendoring/licensing the SDK in CI is out of scope. The repo already commits Release/ReleaseSafe binaries, so the workflow publishes what is tracked at the tagged commit. CI integrity is preserved: unit tests still build + run from source on every push (build-and-test.yml).

## Stacked on #15
Base branch is `features/ci-and-test-coverage`. Once #15 merges, GitHub will retarget this PR to master automatically.

## Test plan
- [ ] After merge, cut a test tag (e.g. `v9.4.0.0-test`) and verify a draft release appears with all three binaries
- [ ] `fail_on_unmatched_files: true` will fail the run if any binary is missing — verifies the contract
- [x] YAML syntax valid (workflow file lints clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)